### PR TITLE
Issue 810

### DIFF
--- a/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -2,7 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
-using System.IO;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -56,15 +56,21 @@ namespace NuGet.PackageManagement
             CancellationToken token)
         {
             // Restoring packages
-            projectContext.Log(ProjectManagement.MessageLevel.Info, Strings.BuildIntegratedPackageRestoreStarted, project.ProjectName);
+            projectContext.Log(ProjectManagement.MessageLevel.Info,
+                Strings.BuildIntegratedPackageRestoreStarted,
+                project.ProjectName);
 
             var packageSources = sources.Select(source => new Configuration.PackageSource(source));
-            var request = new RestoreRequest(packageSpec, packageSources, SettingsUtility.GetGlobalPackagesFolder(settings));
+            var request = new RestoreRequest(packageSpec, packageSources,
+                SettingsUtility.GetGlobalPackagesFolder(settings));
+
             request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
 
             // Find the full closure of project.json files and referenced projects
             var projectReferences = await project.GetProjectReferenceClosureAsync();
-            request.ExternalProjects = projectReferences.Select(reference => BuildIntegratedProjectUtility.ConvertProjectReference(reference)).ToList();
+            request.ExternalProjects = projectReferences
+                .Select(reference => BuildIntegratedProjectUtility.ConvertProjectReference(reference))
+                .ToList();
 
             token.ThrowIfCancellationRequested();
 
@@ -76,11 +82,15 @@ namespace NuGet.PackageManagement
             // Report a final message with the Success result
             if (result.Success)
             {
-                projectContext.Log(ProjectManagement.MessageLevel.Info, Strings.BuildIntegratedPackageRestoreSucceeded, project.ProjectName);
+                projectContext.Log(ProjectManagement.MessageLevel.Info,
+                    Strings.BuildIntegratedPackageRestoreSucceeded,
+                    project.ProjectName);
             }
             else
             {
-                projectContext.Log(ProjectManagement.MessageLevel.Info, Strings.BuildIntegratedPackageRestoreFailed, project.ProjectName);
+                projectContext.Log(ProjectManagement.MessageLevel.Info,
+                    Strings.BuildIntegratedPackageRestoreFailed,
+                    project.ProjectName);
             }
 
             return result;
@@ -89,7 +99,8 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// Find all packages added to <paramref name="updatedLockFile"/>.
         /// </summary>
-        public static IReadOnlyList<PackageIdentity> GetAddedPackages(LockFile originalLockFile, LockFile updatedLockFile)
+        public static IReadOnlyList<PackageIdentity> GetAddedPackages(LockFile originalLockFile,
+            LockFile updatedLockFile)
         {
             var updatedPackages = updatedLockFile.Targets.SelectMany(target => target.Libraries)
                 .Select(library => new PackageIdentity(library.Name, library.Version));
@@ -105,7 +116,8 @@ namespace NuGet.PackageManagement
         /// <summary>
         /// Find all packages removed from <paramref name="updatedLockFile"/>.
         /// </summary>
-        public static IReadOnlyList<PackageIdentity> GetRemovedPackages(LockFile originalLockFile, LockFile updatedLockFile)
+        public static IReadOnlyList<PackageIdentity> GetRemovedPackages(LockFile originalLockFile,
+            LockFile updatedLockFile)
         {
             return GetAddedPackages(updatedLockFile, originalLockFile);
         }

--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -16,8 +16,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
-using NuGet.Packaging.Core;
 using NuGet.Packaging;
+using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
@@ -1324,6 +1324,8 @@ namespace NuGet.PackageManagement
                 rawPackageSpec = JObject.Load(reader);
             }
 
+            var logger = new ProjectContextLogger(nuGetProjectContext);
+
             // If the lock file does not exist, restore before starting the operations
             if (originalLockFile == null)
             {
@@ -1335,7 +1337,7 @@ namespace NuGet.PackageManagement
                 var originalRestoreResult = await BuildIntegratedRestoreUtility.RestoreAsync(
                     buildIntegratedProject,
                     originalPackageSpec,
-                    nuGetProjectContext,
+                    logger,
                     sources,
                     Settings,
                     token);
@@ -1364,7 +1366,7 @@ namespace NuGet.PackageManagement
             // Restore based on the modified package spec. This operation does not write the lock file to disk.
             var restoreResult = await BuildIntegratedRestoreUtility.RestoreAsync(buildIntegratedProject,
                 packageSpec,
-                nuGetProjectContext,
+                logger,
                 sources,
                 Settings,
                 token);

--- a/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
@@ -36,11 +36,16 @@ namespace NuGet.Test
                 };
 
             var projectTargetFramework = NuGetFramework.Parse("uap10.0");
-            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework,
+                new TestNuGetProjectContext());
             var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
 
             // Act
-            var result = await BuildIntegratedRestoreUtility.RestoreAsync(project, new TestNuGetProjectContext(), sources, Configuration.NullSettings.Instance, CancellationToken.None);
+            var result = await BuildIntegratedRestoreUtility.RestoreAsync(project,
+                new TestNuGetProjectContext(),
+                sources,
+                Configuration.NullSettings.Instance,
+                CancellationToken.None);
 
             // Assert
             Assert.True(File.Exists(Path.Combine(projectFolder.FullName, "project.lock.json")));

--- a/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.PackageManagement;
 using NuGet.ProjectManagement.Projects;
@@ -42,7 +41,7 @@ namespace NuGet.Test
 
             // Act
             var result = await BuildIntegratedRestoreUtility.RestoreAsync(project,
-                new TestNuGetProjectContext(),
+                Logging.NullLogger.Instance,
                 sources,
                 Configuration.NullSettings.Instance,
                 CancellationToken.None);


### PR DESCRIPTION
2 commits
1. Clean-up commit. Fixed code to follow coding guidelines
2. Fixes NuGet/Home#810
   Updated BuildIntegratedRestoreUtility to use ILogger, instead of
   INuGetProjectContext, since, we have to convert it to ILogger
   anyways before calling RestoreCommand

@yishaigalatzer , @emgarten, @pranavkm 
