### PR TITLE
Update-Package with exact version fix for UWP projects.

### DIFF
--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -345,8 +345,11 @@ namespace NuGet.PackageManagement
             var projectInstalledPackageReferences = await nuGetProject.GetInstalledPackagesAsync(token);
             var oldListOfInstalledPackages = projectInstalledPackageReferences.Select(p => p.PackageIdentity);
 
+            // Find the id from either the package identity or the packageId directly.
+            var installedPackageId = packageIdentity?.Id ?? packageId;
+
             var installedPackageReference = projectInstalledPackageReferences
-                    .Where(pr => StringComparer.OrdinalIgnoreCase.Equals(pr.PackageIdentity.Id, packageId))
+                    .Where(pr => StringComparer.OrdinalIgnoreCase.Equals(pr.PackageIdentity.Id, installedPackageId))
                     .FirstOrDefault();
 
             // DNX and BuildIntegrated projects are handled here
@@ -382,6 +385,7 @@ namespace NuGet.PackageManagement
                     var action = NuGetProjectAction.CreateInstallProjectAction(updateToIdentity, primarySources.FirstOrDefault());
 
                     var lowLevelActions = new List<NuGetProjectAction>();
+                    lowLevelActions.Add(NuGetProjectAction.CreateUninstallProjectAction(installedPackageReference.PackageIdentity));
                     lowLevelActions.Add(NuGetProjectAction.CreateInstallProjectAction(updateToIdentity, primarySources.FirstOrDefault()));
 
                     var buildIntegratedProject = nuGetProject as BuildIntegratedNuGetProject;

--- a/test/PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/PackageManagement.Test/BuildIntegratedTests.cs
@@ -119,7 +119,7 @@ namespace NuGet.Test
         }
 
         [Fact]
-        public async Task TestPacManBuildIntegratedUpdatePackage()
+        public async Task TestPacManBuildIntegratedInstallUpdatedPackage()
         {
             // Arrange
             var versioning107 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.7"));
@@ -228,6 +228,68 @@ namespace NuGet.Test
         }
 
         [Fact]
+        public async Task TestPacManBuildIntegratedUpdatePackageToExactVersion()
+        {
+            // Arrange
+            var versioning105 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.5"));
+            var versioning107 = new PackageIdentity("nuget.versioning", NuGetVersion.Parse("1.0.7"));
+            var sourceRepositoryProvider = TestSourceRepositoryUtility.CreateV2OnlySourceRepositoryProvider();
+            var testSolutionManager = new TestSolutionManager();
+            var testSettings = new Configuration.NullSettings();
+            var deleteOnRestartManager = new TestDeleteOnRestartManager();
+            var nuGetPackageManager = new NuGetPackageManager(
+                sourceRepositoryProvider,
+                testSettings,
+                testSolutionManager,
+                deleteOnRestartManager);
+
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
+            var token = CancellationToken.None;
+
+            CreateConfigJson(randomConfig);
+
+            var projectTargetFramework = NuGetFramework.Parse("netcore50");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, testNuGetProjectContext, randomProjectFolderPath);
+            var buildIntegratedProject = new BuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+
+            string message = string.Empty;
+
+            await nuGetPackageManager.InstallPackageAsync(buildIntegratedProject, versioning105, new ResolutionContext(), new TestNuGetProjectContext(),
+                    sourceRepositoryProvider.GetRepositories(), sourceRepositoryProvider.GetRepositories(), CancellationToken.None);
+
+            // Act
+            var actions = await nuGetPackageManager.PreviewUpdatePackagesAsync(
+                versioning107,
+                buildIntegratedProject,
+                new ResolutionContext(),
+                new TestNuGetProjectContext(),
+                sourceRepositoryProvider.GetRepositories(),
+                sourceRepositoryProvider.GetRepositories(),
+                CancellationToken.None);
+
+            await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(
+                buildIntegratedProject,
+                actions,
+                new TestNuGetProjectContext(),
+                CancellationToken.None);
+
+            var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);
+            var lockFile = BuildIntegratedProjectUtility.GetLockFilePath(buildIntegratedProject.JsonConfigPath);
+
+            // Assert
+            Assert.Equal(1, actions.Count());
+            Assert.True(actions.First() is BuildIntegratedProjectAction);
+            Assert.Equal(1, installedPackages.Count());
+            Assert.True(installedPackages.Single().PackageIdentity.Version > versioning105.Version);
+            Assert.True(File.Exists(lockFile));
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(testSolutionManager.SolutionDirectory, randomProjectFolderPath);
+        }
+
+        [Fact]
         public async Task TestPacManBuildIntegratedUpdatePackageDowngrade()
         {
             // Arrange
@@ -269,13 +331,19 @@ namespace NuGet.Test
                 sourceRepositoryProvider.GetRepositories(),
                 CancellationToken.None);
 
+            await nuGetPackageManager.ExecuteNuGetProjectActionsAsync(
+                buildIntegratedProject,
+                actions, 
+                new TestNuGetProjectContext(),
+                CancellationToken.None);
+
             var installedPackages = await buildIntegratedProject.GetInstalledPackagesAsync(CancellationToken.None);
             var lockFile = BuildIntegratedProjectUtility.GetLockFilePath(buildIntegratedProject.JsonConfigPath);
 
             // Assert
-            Assert.Equal(0, actions.Count());
+            Assert.Equal(1, actions.Count());
             Assert.Equal(1, installedPackages.Count());
-            Assert.Equal("1.0.5", installedPackages.Single().PackageIdentity.Version.ToNormalizedString());
+            Assert.Equal("1.0.1", installedPackages.Single().PackageIdentity.Version.ToNormalizedString());
             Assert.True(File.Exists(lockFile));
 
             // Clean-up


### PR DESCRIPTION
This fixes update-package where an exact version is passed in but the wrong package id is used to find the already installed package for UWP projects.

https://github.com/NuGet/Home/issues/862

//cc @johnataylor @deepakaravindr @yishaigalatzer 
