### PR TITLE
Adding utility methods for validating lock files.

### DIFF
--- a/src/PackageManagement/BuildIntegration/BuildIntegratedProjectCacheEntry.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedProjectCacheEntry.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+
+namespace NuGet.PackageManagement
+{
+    /// <summary>
+    /// Represents the state of a build integrated project.
+    /// </summary>
+    public class BuildIntegratedProjectCacheEntry
+    {
+        public BuildIntegratedProjectCacheEntry(string projectConfigPath, IEnumerable<string> packageSpecClosure)
+        {
+            if (projectConfigPath == null)
+            {
+                throw new ArgumentNullException(nameof(projectConfigPath));
+            }
+
+            if (packageSpecClosure == null)
+            {
+                throw new ArgumentNullException(nameof(packageSpecClosure));
+            }
+
+            ProjectConfigPath = projectConfigPath;
+            PackageSpecClosure = new HashSet<string>(packageSpecClosure);
+        }
+
+        /// <summary>
+        /// The build integrated project for this entry.
+        /// </summary>
+        public string ProjectConfigPath { get; }
+
+        /// <summary>
+        /// All project.json files in the closure.
+        /// </summary>
+        public HashSet<string> PackageSpecClosure { get; }
+    }
+}

--- a/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -1,13 +1,16 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Commands;
 using NuGet.Configuration;
+using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
@@ -30,8 +33,22 @@ namespace NuGet.PackageManagement
             Configuration.ISettings settings,
             CancellationToken token)
         {
+            var globalPath = SettingsUtility.GetGlobalPackagesFolder(settings);
+            return await RestoreAsync(project, projectContext, sources, globalPath, token);
+        }
+
+        /// <summary>
+        /// Restore a build integrated project and update the lock file
+        /// </summary>
+        public static async Task<RestoreResult> RestoreAsync(
+            BuildIntegratedNuGetProject project,
+            INuGetProjectContext projectContext,
+            IEnumerable<string> sources,
+            string globalPackagesFolderPath,
+            CancellationToken token)
+        {
             // Restore
-            var result = await RestoreAsync(project, project.PackageSpec, projectContext, sources, settings, token);
+            var result = await RestoreAsync(project, project.PackageSpec, projectContext, sources, globalPackagesFolderPath, token);
 
             // Throw before writing if this has been canceled
             token.ThrowIfCancellationRequested();
@@ -55,11 +72,26 @@ namespace NuGet.PackageManagement
             Configuration.ISettings settings,
             CancellationToken token)
         {
+            var globalPath = SettingsUtility.GetGlobalPackagesFolder(settings);
+            return await RestoreAsync(project, packageSpec, projectContext, sources, globalPath, token);
+        }
+
+        /// <summary>
+        /// Restore without writing the lock file
+        /// </summary>
+        internal static async Task<RestoreResult> RestoreAsync(
+            BuildIntegratedNuGetProject project,
+            PackageSpec packageSpec,
+            INuGetProjectContext projectContext,
+            IEnumerable<string> sources,
+            string globalPackageFolderPath,
+            CancellationToken token)
+        {
             // Restoring packages
             projectContext.Log(ProjectManagement.MessageLevel.Info, Strings.BuildIntegratedPackageRestoreStarted, project.ProjectName);
 
             var packageSources = sources.Select(source => new Configuration.PackageSource(source));
-            var request = new RestoreRequest(packageSpec, packageSources, SettingsUtility.GetGlobalPackagesFolder(settings));
+            var request = new RestoreRequest(packageSpec, packageSources, globalPackageFolderPath);
             request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
 
             // Find the full closure of project.json files and referenced projects
@@ -108,6 +140,156 @@ namespace NuGet.PackageManagement
         public static IReadOnlyList<PackageIdentity> GetRemovedPackages(LockFile originalLockFile, LockFile updatedLockFile)
         {
             return GetAddedPackages(updatedLockFile, originalLockFile);
+        }
+
+        /// <summary>
+        /// Creates an index of the project unique name to the cache entry. 
+        /// The cache entry contains the project and the closure of project.json files.
+        /// </summary>
+        public static async Task<IReadOnlyDictionary<string, BuildIntegratedProjectCacheEntry>> 
+            CreateBuildIntegratedProjectStateCache(IReadOnlyList<BuildIntegratedNuGetProject> projects)
+        {
+            var cache = new Dictionary<string, BuildIntegratedProjectCacheEntry>();
+
+            // Find all project closures
+            foreach (var project in projects)
+            {
+                // Get all project.json file paths in the closure
+                var closure = await project.GetProjectReferenceClosureAsync();
+                var files = closure.Select(reference => reference.PackageSpecPath).ToList();
+
+                var projectInfo = new BuildIntegratedProjectCacheEntry(project.JsonConfigPath, files);
+
+                var uniqueName = project.GetMetadata<string>(NuGetProjectMetadataKeys.UniqueName);
+
+                if (!cache.ContainsKey(uniqueName))
+                {
+                    cache.Add(uniqueName, projectInfo);
+                }
+                else
+                {
+                    Debug.Fail("project list contains duplicate projects");
+                }
+            }
+
+            return cache;
+        }
+
+        /// <summary>
+        /// Verifies that the caches contain the same projects and that each project contains the same closure.
+        /// This is used to detect if any projects have changed before verifying the lock files.
+        /// </summary>
+        public static bool CacheHasChanges(IReadOnlyDictionary<string, BuildIntegratedProjectCacheEntry> previousCache,
+            IReadOnlyDictionary<string, BuildIntegratedProjectCacheEntry> currentCache)
+        {
+            foreach (var projectName in currentCache.Keys)
+            {
+                BuildIntegratedProjectCacheEntry projectInfo;
+                if (!previousCache.TryGetValue(projectName, out projectInfo))
+                {
+                    // A new project was added, this needs a restore
+                    return true;
+                }
+
+                if (!currentCache[projectName].PackageSpecClosure.OrderBy(s => s)
+                    .SequenceEqual(projectInfo.PackageSpecClosure.OrderBy(s => s)))
+                {
+                    // The project closure has changed
+                    return true;
+                }
+            }
+
+            // no project changes have occurred
+            return false;
+        }
+
+        /// <summary>
+        /// Validate that all project.lock.json files are validate for the project.json files, and that no packages are missing.
+        /// If a full restore is required this will return false.
+        /// </summary>
+        /// <remarks>Floating versions and project.json files with supports require a full restore.</remarks>
+        public static bool IsRestoreRequired(IReadOnlyList<BuildIntegratedNuGetProject> projects, VersionFolderPathResolver pathResolver)
+        {
+            var hashesChecked = new HashSet<string>();
+
+            var packageSpecs = new Dictionary<string, PackageSpec>();
+
+            // Load all package specs and validate them first for floating versions and supports.
+            foreach (var project in projects)
+            {
+                var path = project.JsonConfigPath;
+
+                if (!packageSpecs.ContainsKey(path))
+                {
+                    var packageSpec = project.PackageSpec;
+
+                    if (packageSpec.RuntimeGraph.Supports.Any())
+                    {
+                        // Compatibility checks need to be done during the restore.
+                        return true;
+                    }
+
+                    if (packageSpec.Dependencies.Any(dependency => dependency.LibraryRange.VersionRange.IsFloating))
+                    {
+                        // Floating dependencies need to be checked each time
+                        return true;
+                    }
+
+                    packageSpecs.Add(path, packageSpec);
+                }
+            }
+
+            // Validate project.lock.json files
+            foreach (var project in projects)
+            {
+                var packageSpec = packageSpecs[project.JsonConfigPath];
+
+                var lockFilePath = BuildIntegratedProjectUtility.GetLockFilePath(project.JsonConfigPath);
+
+                if (!File.Exists(lockFilePath))
+                {
+                    // If the lock file does not exist a restore is needed
+                    return true;
+                }
+
+                var lockFileFormat = new LockFileFormat();
+                var lockFile = lockFileFormat.Read(lockFilePath);
+
+                if (!lockFile.IsValidForPackageSpec(packageSpec))
+                {
+                    // The project.json file has been changed and the lock file needs to be updated.
+                    return true;
+                }
+
+                // Verify all libraries are on disk
+                foreach (var library in lockFile.Libraries)
+                {
+                    // Verify the SHA for each package
+                    var hashPath = pathResolver.GetHashPath(library.Name, library.Version);
+
+                    // Libraries shared between projects can be skipped
+                    if (hashesChecked.Add(hashPath))
+                    {
+                        if (File.Exists(hashPath))
+                        {
+                            var sha512 = File.ReadAllText(hashPath);
+
+                            if (library.Sha512 != sha512)
+                            {
+                                // A package has changed
+                                return true;
+                            }
+                        }
+                        else
+                        {
+                            // A package is missing
+                            return true;
+                        }
+                    }
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/src/PackageManagement/PackageManagement.csproj
+++ b/src/PackageManagement/PackageManagement.csproj
@@ -63,6 +63,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BuildIntegration\BuildIntegratedProjectAction.cs" />
+    <Compile Include="BuildIntegration\BuildIntegratedProjectCacheEntry.cs" />
     <Compile Include="BuildIntegration\BuildIntegratedRestoreUtility.cs" />
     <Compile Include="BuildIntegration\ProjectContextLogger.cs" />
     <Compile Include="Context\IDEExecutionContext.cs" />

--- a/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
@@ -9,7 +9,10 @@ using Newtonsoft.Json.Linq;
 using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.PackageManagement;
+using NuGet.Packaging;
+using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
+using NuGet.Versioning;
 using Test.Utility;
 using Xunit;
 
@@ -17,6 +20,549 @@ namespace NuGet.Test
 {
     public class BuildIntegratedRestoreUtilityTests
     {
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_IsRestoreRequiredDependencyChanged()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var packagesFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var rootFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+            projectFolder.Create();
+            var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+
+            CreateConfigJson(projectConfig.FullName);
+
+            var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+
+            JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+
+            using (var writer = new StreamWriter(projectConfig.FullName))
+            {
+                writer.Write(json.ToString());
+            }
+
+            var sources = new List<string> { "https://www.nuget.org/api/v2/" };
+
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
+            var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+
+            var result = await BuildIntegratedRestoreUtility.RestoreAsync(
+                project,
+                new TestNuGetProjectContext(),
+                sources,
+                packagesFolder,
+                CancellationToken.None);
+
+            var projects = new List<BuildIntegratedNuGetProject>() { project };
+
+            var resolver = new VersionFolderPathResolver(packagesFolder);
+
+            JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.core", VersionRange.Parse("2.8.3")));
+
+            using (var writer = new StreamWriter(projectConfig.FullName))
+            {
+                writer.Write(json.ToString());
+            }
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.IsRestoreRequired(projects, resolver);
+
+            // Assert
+            Assert.True(b);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(rootFolder, packagesFolder);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_IsRestoreRequiredChangedSha512()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var packagesFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var rootFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+            projectFolder.Create();
+            var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+
+            CreateConfigJson(projectConfig.FullName);
+
+            var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+
+            JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+
+            using (var writer = new StreamWriter(projectConfig.FullName))
+            {
+                writer.Write(json.ToString());
+            }
+
+            var sources = new List<string> { "https://www.nuget.org/api/v2/" };
+
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
+            var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+
+            var result = await BuildIntegratedRestoreUtility.RestoreAsync(
+                project,
+                new TestNuGetProjectContext(),
+                sources,
+                packagesFolder,
+                CancellationToken.None);
+
+            var projects = new List<BuildIntegratedNuGetProject>() { project };
+
+            var resolver = new VersionFolderPathResolver(packagesFolder);
+
+            var hashPath = resolver.GetHashPath("nuget.versioning", NuGetVersion.Parse("1.0.7"));
+
+            using (var writer = new StreamWriter(hashPath))
+            {
+                writer.Write("ANAWESOMELYWRONGHASH!!!");
+            }
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.IsRestoreRequired(projects, resolver);
+
+            // Assert
+            Assert.True(b);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(rootFolder, packagesFolder);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_IsRestoreRequiredMissingPackage()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var packagesFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var rootFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+            projectFolder.Create();
+            var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+
+            CreateConfigJson(projectConfig.FullName);
+
+            var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+
+            JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+
+            using (var writer = new StreamWriter(projectConfig.FullName))
+            {
+                writer.Write(json.ToString());
+            }
+
+            var sources = new List<string> { "https://www.nuget.org/api/v2/" };
+
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
+            var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+
+            var result = await BuildIntegratedRestoreUtility.RestoreAsync(
+                project,
+                new TestNuGetProjectContext(),
+                sources,
+                packagesFolder,
+                CancellationToken.None);
+
+            var projects = new List<BuildIntegratedNuGetProject>() { project };
+
+            var resolver = new VersionFolderPathResolver(packagesFolder);
+
+            // Act
+            Directory.Delete(resolver.GetInstallPath("nuget.versioning", NuGetVersion.Parse("1.0.7")), true);
+            var b = BuildIntegratedRestoreUtility.IsRestoreRequired(projects, resolver);
+
+            // Assert
+            Assert.True(b);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(rootFolder, packagesFolder);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_IsRestoreRequiredWithSupports()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var rootFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+            projectFolder.Create();
+            var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+
+            CreateConfigJson(projectConfig.FullName);
+
+            var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+
+            JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+
+            json.Add("supports", JObject.Parse("{ \"uap10-x86\": { }, \"uap10-x86-aot\": { } }"));
+
+            using (var writer = new StreamWriter(projectConfig.FullName))
+            {
+                writer.Write(json.ToString());
+            }
+
+            var sources = new List<string> { "https://www.nuget.org/api/v2/" };
+
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
+            var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+
+            var result = await BuildIntegratedRestoreUtility.RestoreAsync(project,
+                new TestNuGetProjectContext(),
+                sources,
+                Configuration.NullSettings.Instance,
+                CancellationToken.None);
+
+            var projects = new List<BuildIntegratedNuGetProject>() { project };
+
+            var packagesFolder = SettingsUtility.GetGlobalPackagesFolder(Configuration.NullSettings.Instance);
+
+            var resolver = new VersionFolderPathResolver(packagesFolder);
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.IsRestoreRequired(projects, resolver);
+
+            // Assert
+            Assert.True(b);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(rootFolder);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_IsRestoreRequiredWithFloatingVersion()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var rootFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+            projectFolder.Create();
+            var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+
+            CreateConfigJson(projectConfig.FullName);
+
+            var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+
+            JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.*")));
+
+            using (var writer = new StreamWriter(projectConfig.FullName))
+            {
+                writer.Write(json.ToString());
+            }
+
+            var sources = new List<string> { "https://www.nuget.org/api/v2/" };
+
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
+            var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+
+            var result = await BuildIntegratedRestoreUtility.RestoreAsync(project,
+                new TestNuGetProjectContext(),
+                sources,
+                Configuration.NullSettings.Instance,
+                CancellationToken.None);
+
+            var projects = new List<BuildIntegratedNuGetProject>() { project };
+
+            var packagesFolder = SettingsUtility.GetGlobalPackagesFolder(Configuration.NullSettings.Instance);
+
+            var resolver = new VersionFolderPathResolver(packagesFolder);
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.IsRestoreRequired(projects, resolver);
+
+            // Assert
+            Assert.True(b);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(rootFolder);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_IsRestoreRequiredWithNoChanges()
+        {
+            // Arrange
+            var projectName = "testproj";
+
+            var rootFolder = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectFolder = new DirectoryInfo(Path.Combine(rootFolder, projectName));
+            projectFolder.Create();
+            var projectConfig = new FileInfo(Path.Combine(projectFolder.FullName, "project.json"));
+
+            CreateConfigJson(projectConfig.FullName);
+
+            var json = JObject.Parse(File.ReadAllText(projectConfig.FullName));
+
+            JsonConfigUtility.AddDependency(json, new NuGet.Packaging.Core.PackageDependency("nuget.versioning", VersionRange.Parse("1.0.7")));
+
+            using (var writer = new StreamWriter(projectConfig.FullName))
+            {
+                writer.Write(json.ToString());
+            }
+
+            var sources = new List<string> { "https://www.nuget.org/api/v2/" };
+
+            var projectTargetFramework = NuGetFramework.Parse("uap10.0");
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(projectTargetFramework, new TestNuGetProjectContext());
+            var project = new BuildIntegratedNuGetProject(projectConfig.FullName, msBuildNuGetProjectSystem);
+
+            var result = await BuildIntegratedRestoreUtility.RestoreAsync(project,
+                new TestNuGetProjectContext(),
+                sources,
+                Configuration.NullSettings.Instance,
+                CancellationToken.None);
+
+            var projects = new List<BuildIntegratedNuGetProject>() { project };
+
+            var packagesFolder = SettingsUtility.GetGlobalPackagesFolder(Configuration.NullSettings.Instance);
+
+            var resolver = new VersionFolderPathResolver(packagesFolder);
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.IsRestoreRequired(projects, resolver);
+
+            // Assert
+            Assert.False(b);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(rootFolder);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_CacheDiffersOnClosure()
+        {
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
+            var randomProjectFolderPath2 = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig2 = Path.Combine(randomProjectFolderPath2, "project.json");
+            CreateConfigJson(randomConfig);
+            CreateConfigJson(randomConfig2);
+
+            var projectTargetFramework = NuGetFramework.Parse("netcore50");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath,
+                "project1");
+
+            var project1 = new TestBuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+            project1.ProjectClosure = new List<BuildIntegratedProjectReference>()
+            {
+                new BuildIntegratedProjectReference("a", "a/project.json", new string[] { "b/project.json" }),
+                new BuildIntegratedProjectReference("b", "b/project.json", new string[] { }),
+            };
+
+            var msBuildNuGetProjectSystem2 = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath2,
+                "project2");
+
+            var project2 = new TestBuildIntegratedNuGetProject(randomConfig2, msBuildNuGetProjectSystem2);
+            project2.ProjectClosure = new List<BuildIntegratedProjectReference>() { };
+
+            var projects = new List<BuildIntegratedNuGetProject>();
+            projects.Add(project1);
+            projects.Add(project2);
+
+            var cache = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects);
+
+            var projects2 = new List<BuildIntegratedNuGetProject>();
+            project1.ProjectClosure = new List<BuildIntegratedProjectReference>() {
+                new BuildIntegratedProjectReference("a", "a/project.json", new string[] { "d/project.json" }),
+                new BuildIntegratedProjectReference("d", "d/project.json", new string[] { }),
+            };
+
+            projects2.Add(project1);
+            projects2.Add(project2);
+            var cache2 = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects2);
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.CacheHasChanges(cache, cache2);
+
+            // Assert
+            Assert.True(b);
+
+            // Clean up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath, randomProjectFolderPath2);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_CacheDiffersOnProjects()
+        {
+            // Arrange
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
+            var randomProjectFolderPath2 = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig2 = Path.Combine(randomProjectFolderPath2, "project.json");
+            CreateConfigJson(randomConfig);
+            CreateConfigJson(randomConfig2);
+
+            var projectTargetFramework = NuGetFramework.Parse("netcore50");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath,
+                "project1");
+
+            var project1 = new TestBuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+            project1.ProjectClosure = new List<BuildIntegratedProjectReference>()
+            {
+                new BuildIntegratedProjectReference("a", "a/project.json", new string[] { "b/project.json" }),
+                new BuildIntegratedProjectReference("b", "b/project.json", new string[] { }),
+            };
+
+            var msBuildNuGetProjectSystem2 = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath2,
+                "project2");
+
+            var project2 = new TestBuildIntegratedNuGetProject(randomConfig2, msBuildNuGetProjectSystem2);
+            project2.ProjectClosure = new List<BuildIntegratedProjectReference>() { };
+
+            var projects = new List<BuildIntegratedNuGetProject>();
+            projects.Add(project1);
+
+            var cache = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects);
+
+            // Add a new project to the second cache
+            projects.Add(project2);
+            var cache2 = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects);
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.CacheHasChanges(cache, cache2);
+
+            // Assert
+            Assert.True(b);
+
+            // Clean up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath, randomProjectFolderPath2);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_SameCache()
+        {
+            // Arrange
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
+            var randomProjectFolderPath2 = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig2 = Path.Combine(randomProjectFolderPath2, "project.json");
+            CreateConfigJson(randomConfig);
+            CreateConfigJson(randomConfig2);
+
+            var projectTargetFramework = NuGetFramework.Parse("netcore50");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath,
+                "project1");
+
+            var project1 = new TestBuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+            project1.ProjectClosure = new List<BuildIntegratedProjectReference>()
+            {
+                new BuildIntegratedProjectReference("a", "a/project.json", new string[] { "b/project.json" }),
+                new BuildIntegratedProjectReference("b", "b/project.json", new string[] { }),
+            };
+
+            var msBuildNuGetProjectSystem2 = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath2,
+                "project2");
+
+            var project2 = new TestBuildIntegratedNuGetProject(randomConfig2, msBuildNuGetProjectSystem2);
+            project2.ProjectClosure = new List<BuildIntegratedProjectReference>() { };
+
+            var projects = new List<BuildIntegratedNuGetProject>();
+            projects.Add(project1);
+            projects.Add(project2);
+
+            var cache = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects);
+            var cache2 = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects);
+
+            // Act
+            var b = BuildIntegratedRestoreUtility.CacheHasChanges(cache, cache2);
+
+            // Assert
+            Assert.False(b);
+
+            // Clean up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath, randomProjectFolderPath2);
+        }
+
+        [Fact]
+        public async Task BuildIntegratedRestoreUtility_CreateCache()
+        {
+            // Arrange
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig = Path.Combine(randomProjectFolderPath, "project.json");
+            var randomProjectFolderPath2 = TestFilesystemUtility.CreateRandomTestFolder();
+            var randomConfig2 = Path.Combine(randomProjectFolderPath2, "project.json");
+            CreateConfigJson(randomConfig);
+            CreateConfigJson(randomConfig2);
+
+            var projectTargetFramework = NuGetFramework.Parse("netcore50");
+            var testNuGetProjectContext = new TestNuGetProjectContext();
+
+            var msBuildNuGetProjectSystem = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath,
+                "project1");
+
+            var project1 = new TestBuildIntegratedNuGetProject(randomConfig, msBuildNuGetProjectSystem);
+            project1.ProjectClosure = new List<BuildIntegratedProjectReference>()
+            {
+                new BuildIntegratedProjectReference("a", "a/project.json", new string[] { "b/project.json" }),
+                new BuildIntegratedProjectReference("b", "b/project.json", new string[] { }),
+            };
+
+            var msBuildNuGetProjectSystem2 = new TestMSBuildNuGetProjectSystem(
+                projectTargetFramework,
+                testNuGetProjectContext,
+                randomProjectFolderPath2,
+                "project2");
+
+            var project2 = new TestBuildIntegratedNuGetProject(randomConfig2, msBuildNuGetProjectSystem2);
+            project2.ProjectClosure = new List<BuildIntegratedProjectReference>() { };
+
+            var projects = new List<BuildIntegratedNuGetProject>();
+            projects.Add(project1);
+            projects.Add(project2);
+
+            // Act
+            var cache = await BuildIntegratedRestoreUtility.CreateBuildIntegratedProjectStateCache(projects);
+
+            // Assert
+            Assert.Equal(2, cache.Count);
+            Assert.Equal(2, cache["project1"].PackageSpecClosure.Count);
+            Assert.Equal(0, cache["project2"].PackageSpecClosure.Count);
+            Assert.Equal("a/project.json|b/project.json", string.Join("|", cache["project1"].PackageSpecClosure));
+
+            // Clean up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath, randomProjectFolderPath2);
+        }
+
         [Fact]
         public async Task BuildIntegratedRestoreUtility_BasicRestoreTest()
         {
@@ -72,6 +618,23 @@ namespace NuGet.Test
                 json.Add("runtimes", JObject.Parse("{ \"uap10-x86\": { }, \"uap10-x86-aot\": { } }"));
 
                 return json;
+            }
+        }
+
+
+        private class TestBuildIntegratedNuGetProject : BuildIntegratedNuGetProject
+        {
+            public IReadOnlyList<BuildIntegratedProjectReference> ProjectClosure { get; set;}
+
+            public TestBuildIntegratedNuGetProject(string jsonConfig, IMSBuildNuGetProjectSystem msbuildProjectSystem)
+                : base(jsonConfig, msbuildProjectSystem)
+            {
+                InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, msbuildProjectSystem.ProjectName);
+            }
+
+            public override Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync()
+            {
+                return Task.FromResult(ProjectClosure);
             }
         }
     }


### PR DESCRIPTION
This change contains the helper methods used by the VS on build event to validate lock files before building.

https://github.com/NuGet/Home/issues/845
https://github.com/NuGet/Home/issues/844

//cc @yishaigalatzer @anurse @deepakaravindr 
