### PR TITLE
* Only include project references that have project.json when conside…

### DIFF
--- a/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -1,10 +1,9 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -97,7 +96,10 @@ namespace NuGet.PackageManagement
 
             // Find the full closure of project.json files and referenced projects
             var projectReferences = await project.GetProjectReferenceClosureAsync();
-            request.ExternalProjects = projectReferences.Select(reference => BuildIntegratedProjectUtility.ConvertProjectReference(reference)).ToList();
+            request.ExternalProjects = projectReferences
+                .Where(reference => !string.IsNullOrEmpty(reference.PackageSpecPath))
+                .Select(reference => BuildIntegratedProjectUtility.ConvertProjectReference(reference))
+                .ToList();
 
             token.ThrowIfCancellationRequested();
 
@@ -151,7 +153,7 @@ namespace NuGet.PackageManagement
         /// Creates an index of the project unique name to the cache entry. 
         /// The cache entry contains the project and the closure of project.json files.
         /// </summary>
-        public static async Task<IReadOnlyDictionary<string, BuildIntegratedProjectCacheEntry>> 
+        public static async Task<IReadOnlyDictionary<string, BuildIntegratedProjectCacheEntry>>
             CreateBuildIntegratedProjectStateCache(IReadOnlyList<BuildIntegratedNuGetProject> projects)
         {
             var cache = new Dictionary<string, BuildIntegratedProjectCacheEntry>();

--- a/src/ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
+++ b/src/ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
@@ -6,8 +6,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using NuGet.Configuration;
-using NuGet.Frameworks;
-using NuGet.LibraryModel;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement.Projects;
@@ -61,7 +59,10 @@ namespace NuGet.ProjectManagement
         /// </summary>
         public static ExternalProjectReference ConvertProjectReference(BuildIntegratedProjectReference reference)
         {
-            return new ExternalProjectReference(reference.Name, reference.PackageSpecPath, reference.ExternalProjectReferences);
+            return new ExternalProjectReference(
+                reference.Name,
+                reference.PackageSpecPath,
+                reference.ExternalProjectReferences.Where(externalReference => !externalReference.Equals(reference.Name, StringComparison.OrdinalIgnoreCase)));
         }
 
         public static IReadOnlyList<PackageIdentity> GetOrderedProjectDependencies(BuildIntegratedNuGetProject buildIntegratedProject)


### PR DESCRIPTION
…ring

the build integrated transitive closure.
- Remove cyclic dependencies from external project dependencies.
