### PR TITLE
Package restore fixes part I

### DIFF
--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -253,7 +253,7 @@ namespace NuGet.CommandLine
                 packageRestoredEvent: null,
                 packageRestoreFailedEvent: null,
                 sourceRepositories: packageSources,
-                maxNumberOfParallelTasks: PackageManagementConstants.DefaultMaxDegreeOfParallelism);
+                maxNumberOfParallelTasks: DisableParallelProcessing ? 1 : PackageManagementConstants.DefaultMaxDegreeOfParallelism);
 
             return PackageRestoreManager.RestoreMissingPackagesAsync(packageRestoreContext, new ConsoleProjectContext(Logger));
         }

--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -229,7 +229,17 @@ namespace NuGet.CommandLine
                 installedPackageReferences = GetInstalledPackageReferences(_packagesConfigFileFullPath);
             }
 
-            var packageRestoreData = installedPackageReferences.Select(reference =>
+            var missingPackageReferences = installedPackageReferences.Where(reference =>
+                !nuGetPackageManager.PackageExistsInPackagesFolder(reference.PackageIdentity));
+
+            if (!missingPackageReferences.Any())
+            {
+                var message = string.Format(NuGetResources.InstallCommandNothingToInstall, "packages.config");
+                Logger.LogInformation(message);
+                return Task.FromResult(0);
+            }
+
+            var packageRestoreData = missingPackageReferences.Select(reference =>
                 new PackageRestoreData(
                     reference,
                     new[] { _solutionFileFullPath ?? _packagesConfigFileFullPath },


### PR DESCRIPTION
@pranavkm @feiling @emgarten 

2 minor fixes in this part as separate commits. Will be 2 or 3 more minor fixes in the next part
1. When all packages are already restored, message 'All packages are already installed' is not shown.
   Instead, an attempt to restore all installed packages is made and there is
   a lot of unnecessary logging
2. -DisableParallelProcessing switch was not honored in case of packages.config
