### PR TITLE
Package restore fixes part II

### DIFF
--- a/src/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -10287,7 +10287,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to If a solution is specified, this command restores NuGet packages that are installed in the solution and in projects contained in the solution. Otherwise, the command restores packages listed in the specified packages.config file..
+        ///   Looks up a localized string similar to If a solution is specified, this command restores NuGet packages that are installed in the solution and in projects contained in the solution. Otherwise, the command restores packages listed in the specified packages.config file or project.json file..
         /// </summary>
         internal static string RestoreCommandUsageDescription {
             get {
@@ -10413,7 +10413,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to [&lt;solution&gt; | &lt;packages.config file&gt;] [options].
+        ///   Looks up a localized string similar to [&lt;solution&gt; | &lt;packages.config file&gt; | &lt;project.json&gt;] [options].
         /// </summary>
         internal static string RestoreCommandUsageSummary {
             get {

--- a/src/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.CommandLine/NuGetCommand.resx
@@ -482,10 +482,10 @@ nuget update -Self</value>
     <value>Specifies the solution directory. Not valid when restoring packages for a solution.</value>
   </data>
   <data name="RestoreCommandUsageDescription" xml:space="preserve">
-    <value>If a solution is specified, this command restores NuGet packages that are installed in the solution and in projects contained in the solution. Otherwise, the command restores packages listed in the specified packages.config file.</value>
+    <value>If a solution is specified, this command restores NuGet packages that are installed in the solution and in projects contained in the solution. Otherwise, the command restores packages listed in the specified packages.config file or project.json file.</value>
   </data>
   <data name="RestoreCommandUsageSummary" xml:space="preserve">
-    <value>[&lt;solution&gt; | &lt;packages.config file&gt;] [options]</value>
+    <value>[&lt;solution&gt; | &lt;packages.config file&gt; | &lt;project.json&gt;] [options]</value>
     <comment>Please don't localize "packages.config"</comment>
   </data>
   <data name="ConfigCommandDesc_csy" xml:space="preserve">


### PR DESCRIPTION
@pranavkm @feiling @emgarten 
1. RestoreCommand honors RequireConsent switch now. If the consent is not …
   granted, with the switch, nuget restore will fail with an error message.
   If the consent is granted, with the switch, it will display an info message
   on how to disable automatic restore and continue with restore
2. Fixed help message for nuget restore to show project.json as an input …
   option
