### PR TITLE
Package install fixes

### DIFF
--- a/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -27,9 +27,6 @@ namespace NuGet.CommandLine
             get { return _sources; }
         }
 
-        [Option(typeof(NuGetCommand), "CommandFallbackSourceDescription")]
-        public ICollection<string> FallbackSource { get; } = new List<string>();
-
         [Option(typeof(NuGetCommand), "CommandNoCache")]
         public bool NoCache { get; set; }
 
@@ -96,12 +93,7 @@ namespace NuGet.CommandLine
 
             if (packageSources.Count == 0)
             {
-                packageSources.AddRange(packageSourceProvider.LoadPackageSources());
-            }
-
-            foreach (var source in FallbackSource)
-            {
-                packageSources.Add(Common.PackageSourceProviderExtensions.ResolveSource(packageSources, source));
+                packageSources.AddRange(availableSources);
             }
 
             return packageSources;

--- a/src/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -1,6 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel.Composition;
-using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -42,6 +42,9 @@ namespace NuGet.CommandLine
 
         [Option(typeof(NuGetCommand), "InstallCommandSolutionDirectory")]
         public string SolutionDirectory { get; set; }
+
+        [Option(typeof(NuGetCommand), "CommandFallbackSourceDescription")]
+        public ICollection<string> FallbackSource { get; } = new List<string>();
 
         private bool AllowMultipleVersions
         {
@@ -172,6 +175,17 @@ namespace NuGet.CommandLine
             return sourceRepositoryProvider;
         }
 
+        private List<Configuration.PackageSource> GetFallbackSources()
+        {
+            var packageSources = new List<Configuration.PackageSource>();
+            foreach (var source in FallbackSource)
+            {
+                packageSources.Add(Common.PackageSourceProviderExtensions.ResolveSource(packageSources, source));
+            }
+
+            return packageSources;
+        }
+
         private Task InstallPackage(
             string packageId,
             NuGetVersion version,
@@ -190,6 +204,7 @@ namespace NuGet.CommandLine
             var packageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, installPath);
 
             var primaryRepositories = GetPackageSources(Settings).Select(sourceRepositoryProvider.CreateRepository);
+            var fallbackRepositories = GetFallbackSources().Select(sourceRepositoryProvider.CreateRepository);
 
             if (version == null)
             {
@@ -204,7 +219,7 @@ namespace NuGet.CommandLine
                         versionConstraints: VersionConstraints.None),
                     new ConsoleProjectContext(Logger),
                     primaryRepositories,
-                    Enumerable.Empty<SourceRepository>(),
+                    fallbackRepositories,
                     CancellationToken.None);
             }
             else
@@ -219,7 +234,7 @@ namespace NuGet.CommandLine
                         versionConstraints: VersionConstraints.None),
                     new ConsoleProjectContext(Logger),
                     primaryRepositories,
-                    Enumerable.Empty<SourceRepository>(),
+                    fallbackRepositories,
                     CancellationToken.None);
             }
         }

--- a/src/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -4750,6 +4750,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to find package &apos;{0}&apos;.
+        /// </summary>
+        public static string InstallCommandUnableToFindPackage {
+            get {
+                return ResourceManager.GetString("InstallCommandUnableToFindPackage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}: invalid arguments..
         /// </summary>
         public static string InvalidArguments {

--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -6027,4 +6027,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="SettingsCredentials_UsingSavedCredentials" xml:space="preserve">
     <value>Using credentials from config. UserName: {0}</value>
   </data>
+  <data name="InstallCommandUnableToFindPackage" xml:space="preserve">
+    <value>Unable to find package '{0}'</value>
+  </data>
 </root>

--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -1718,8 +1718,11 @@ namespace NuGet.PackageManagement
             return GetLatestVersionAsync(packageId, resolutionContext, new List<SourceRepository> { primarySourceRepository }, token);
         }
 
-        private static async Task<NuGetVersion> GetLatestVersionAsync(string packageId, ResolutionContext resolutionContext,
-            IEnumerable<SourceRepository> sources, CancellationToken token)
+        public static async Task<NuGetVersion> GetLatestVersionAsync(
+            string packageId,
+            ResolutionContext resolutionContext,
+            IEnumerable<SourceRepository> sources,
+            CancellationToken token)
         {
             var tasks = new List<Task<NuGetVersion>>();
 


### PR DESCRIPTION
This commit fixes issues related to disabled sources and fallback sources.
Will add more commits to this PR
1. nuget restore and install were installing from disabled sources too.
   This changes fixes that.
2. Plus, making the new option -FallbackSource
   only available for nuget install. And, using fallback sources as
   secondary sources when calling into nuGetPackageManager.Install
