### PR TITLE
Refactoring commit for tests

### DIFF
--- a/test/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetConfigCommandTest.cs
@@ -1,9 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NuGet.CommandLine.Test

--- a/test/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -1,11 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -16,8 +11,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void DeleteCommand_DeleteFromFileSystemSource()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var source = Path.Combine(tempPath, Guid.NewGuid().ToString());
             try
@@ -54,8 +48,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void DeleteCommand_DeleteFromFileSystemSourceUnixStyle()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var source = Path.Combine(tempPath, Guid.NewGuid().ToString());
             source = source.Replace(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
@@ -90,8 +83,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void DeleteCommand_DeleteFromHttpSource()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var mockServerEndPoint = "http://localhost:1234/";
 

--- a/test/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetHelpCommandTest.cs
@@ -1,10 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -26,8 +21,7 @@ namespace NuGet.CommandLine.Test
         public void HelpCommand_HelpMessage(string command)
         {
             // Arrange
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             // Act
             var r = CommandRunner.Run(
@@ -45,8 +39,7 @@ namespace NuGet.CommandLine.Test
         public void HelpCommand_SpecCommand()
         {
             // Arrange
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             // Act
             var r = CommandRunner.Run(

--- a/test/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -11,10 +10,7 @@ namespace NuGet.CommandLine.Test
 {
     public class NuGetInstallCommandTest
     {
-        /*
-        Disable those tests because PackageSaveMode is not currently supported.
-
-        [Fact]
+        [Fact(Skip = "PackageSaveMode is not supported yet")]
         public void InstallCommand_PackageSaveModeNuspec()
         {
             var tempPath = Path.GetTempPath();
@@ -57,7 +53,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "PackageSaveMode is not supported yet")]
         public void InstallCommand_PackageSaveModeNupkg()
         {
             var tempPath = Path.GetTempPath();
@@ -100,7 +96,7 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        [Fact]
+        [Fact(Skip = "PackageSaveMode is not supported yet")]
         public void InstallCommand_PackageSaveModeNuspecNupkg()
         {
             var tempPath = Path.GetTempPath();
@@ -146,7 +142,7 @@ namespace NuGet.CommandLine.Test
         // Test that after a package is installed with -PackageSaveMode nuspec, nuget.exe
         // can detect that the package is already installed when trying to install the same
         // package.
-        [Fact]
+        [Fact(Skip = "PackageSaveMode is not supported yet")]
         public void InstallCommand_PackageSaveModeNuspecReinstall()
         {
             var tempPath = Path.GetTempPath();
@@ -192,7 +188,7 @@ namespace NuGet.CommandLine.Test
         }
 
         // Test that PackageSaveMode specified in nuget.config file is used.
-        [Fact]
+        [Fact(Skip = "PackageSaveMode is not supported yet")]
         public void InstallCommand_PackageSaveModeInConfigFile()
         {
             var tempPath = Path.GetTempPath();
@@ -241,7 +237,7 @@ namespace NuGet.CommandLine.Test
                 Util.DeleteDirectory(outputDirectory);
                 Util.DeleteDirectory(source);
             }
-        } */
+        }
 
         // Tests that when package restore is enabled and -RequireConsent is specified,
         // the opt out message is displayed.
@@ -256,8 +252,7 @@ namespace NuGet.CommandLine.Test
             var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -328,8 +323,7 @@ namespace NuGet.CommandLine.Test
             var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -392,8 +386,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_GetLastestReleaseVersion()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
@@ -442,8 +435,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_GetLastestPrereleaseVersion()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
@@ -493,8 +485,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_WithVersionSpecified()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
@@ -567,8 +558,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_WillTryNewVersionsByAppendingZeros()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var mockServerEndPoint = "http://localhost:1234/";
@@ -627,8 +617,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_WillUseCachedFile()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
@@ -714,8 +703,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_DownloadPackageWhenHashChanges()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
@@ -806,8 +794,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_PreferNonSymbolPackage()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var source = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var outputDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
@@ -858,8 +845,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void InstallCommand_DependencyResolutionFailure()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var source = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var outputDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());

--- a/test/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Configuration;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -16,8 +15,7 @@ namespace NuGet.CommandLine.Test
         [Fact]
         public void PackCommand_WithProjectReferences()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -127,8 +125,7 @@ namespace Proj2
         [Fact]
         public void PackCommand_WithProjectReferencesSymbols()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -243,8 +240,7 @@ namespace Proj2
         [Fact]
         public void PackCommand_ReferencedProjectWithNuspecFile()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -364,8 +360,7 @@ namespace Proj2
         {
             const string prefixTokenValue = "fooBar";
 
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -470,8 +465,7 @@ namespace Proj2
         [Fact]
         public void PackCommand_NuspecFileWithTokens()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -546,8 +540,7 @@ namespace Proj2
         [Fact]
         public void PackCommand_ProjectReferencedByMultipleProjects()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -604,8 +597,7 @@ namespace Proj2
         [Fact]
         public void PackCommand_ReferencedProjectWithDifferentTarget()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -653,8 +645,7 @@ namespace Proj2
         [Fact(Skip = "This test failed on dev10 build with mysterious errors. Will reenable it once the cause is figured out")]
         public void PackCommand_IncludeReferencedProjectsOff()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             var oldCurrentDirectory = Directory.GetCurrentDirectory();
 
@@ -788,8 +779,7 @@ namespace Proj2
         [Fact]
         public void PackCommand_PropertiesAppliedToReferencedProjects()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -916,8 +906,7 @@ namespace Proj2
         [Fact]
         public void PackCommand_ExcludesFilesOutsideRoot()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             var projDirectory = Path.Combine(workingDirectory, "package");
@@ -983,8 +972,7 @@ namespace Proj2
         [InlineData("packages.proj1.config")]
         public void PackCommand_PackagesAddedAsDependencies(string packagesConfigFileName)
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try
@@ -1078,8 +1066,7 @@ namespace Proj1
         [Fact]
         public void PackCommand_WarningDependencyVersionNotSpecified()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
 
             try

--- a/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1,12 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Configuration;
 using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Net;
-using System.Text;
-using System.Threading.Tasks;
 using Xunit;
 
 namespace NuGet.CommandLine.Test
@@ -21,8 +16,7 @@ namespace NuGet.CommandLine.Test
             var workingPath = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -71,8 +65,7 @@ namespace NuGet.CommandLine.Test
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var proj2Directory = Path.Combine(workingPath, "proj2");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -159,8 +152,7 @@ EndProject");
             var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -224,8 +216,7 @@ EndProject");
             var workingPath = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -285,8 +276,7 @@ EndProject");
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var proj2Directory = Path.Combine(workingPath, "proj2");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -387,8 +377,7 @@ EndProject");
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var proj2Directory = Path.Combine(workingPath, "proj2");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -491,8 +480,7 @@ EndProject");
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var proj2Directory = Path.Combine(workingPath, "proj2");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -580,8 +568,7 @@ EndProject");
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var proj2Directory = Path.Combine(workingPath, "proj2");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -678,8 +665,7 @@ EndProject");
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var proj2Directory = Path.Combine(workingPath, "proj2");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -758,8 +744,7 @@ EndProject");
             var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -833,8 +818,7 @@ EndProject");
             var proj1Directory = Path.Combine(workingPath, "proj1");
             var proj2Directory = Path.Combine(workingPath, "proj2");
             var currentDirectory = Directory.GetCurrentDirectory();
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
 
             try
             {
@@ -918,8 +902,7 @@ EndProject");
         [Fact]
         public void RestoreCommand_FromHttpSource()
         {
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
             var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
             var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());

--- a/test/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Configuration;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -99,8 +98,7 @@ namespace NuGet.CommandLine
         public void EnsureProjectFactoryDoesNotAddFileThatIsAlreadyInPackage()
         {
             // Setup
-            var targetDir = ConfigurationManager.AppSettings["TargetDir"];
-            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            var nugetexe = Util.GetNuGetExePath();
             var workingDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
             try
             {

--- a/test/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.CommandLine.Test/Util.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Configuration;
 using System.Globalization;
 using System.IO;
 using System.Net;
@@ -150,6 +151,13 @@ namespace NuGet.CommandLine.Test
 
             server.Get.Add("/nuget", r => "OK");
             return server;
+        }
+
+        public static string GetNuGetExePath()
+        {
+            var targetDir = ConfigurationManager.AppSettings["TargetDir"] ?? Directory.GetCurrentDirectory();
+            var nugetexe = Path.Combine(targetDir, "nuget.exe");
+            return nugetexe;
         }
     }
 }


### PR DESCRIPTION
1. Refactored GetNuGetExePath into a static method in Util class. Helps run tests via TestExplorer in VS without it failing because of ConfigurationManager.AppSettings["TargetDir"] being null
2. Uncommented out a lot of commented out tests for nuget install and
   marked them to be skipped since PackageSaveMode is not supported

@pranavkm @emgarten
