### PR TITLE
Restore parent projects during transitive package operations

### DIFF
--- a/src/PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedProjectAction.cs
@@ -24,11 +24,17 @@ namespace NuGet.PackageManagement
         /// </summary>
         public JObject UpdatedProjectJson { get; }
 
+        /// <summary>
+        /// Sources used for package restore.
+        /// </summary>
+        public IReadOnlyList<string> Sources { get; }
+
         public BuildIntegratedProjectAction(PackageIdentity packageIdentity,
             NuGetProjectActionType nuGetProjectActionType,
             LockFile originalLockFile,
             JObject updatedProjectJson,
-            RestoreResult restoreResult)
+            RestoreResult restoreResult,
+            IReadOnlyList<string> sources)
             : base(packageIdentity, nuGetProjectActionType)
         {
             if (packageIdentity == null)
@@ -51,9 +57,15 @@ namespace NuGet.PackageManagement
                 throw new ArgumentNullException(nameof(restoreResult));
             }
 
+            if (sources == null)
+            {
+                throw new ArgumentNullException(nameof(sources));
+            }
+
             OriginalLockFile = originalLockFile;
             RestoreResult = restoreResult;
             UpdatedProjectJson = updatedProjectJson;
+            Sources = sources;
         }
 
         public IReadOnlyList<NuGetProjectAction> GetProjectActions()

--- a/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -95,6 +95,9 @@ namespace NuGet.PackageManagement
             var request = new RestoreRequest(packageSpec, packageSources, globalPackageFolderPath);
             request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
 
+            // Add the existing lock file if it exists
+            request.ExistingLockFile = GetLockFile(project, logger);
+
             // Find the full closure of project.json files and referenced projects
             var projectReferences = await project.GetProjectReferenceClosureAsync();
             request.ExternalProjects = projectReferences
@@ -303,6 +306,80 @@ namespace NuGet.PackageManagement
             }
 
             return false;
+        }
+
+        /// <summary>
+        /// Find the list of parent projects which directly or indirectly reference the child project.
+        /// </summary>
+        public static async Task<IReadOnlyList<BuildIntegratedNuGetProject>> GetParentProjectsInClosure(
+            ISolutionManager solutionManager,
+            BuildIntegratedNuGetProject target)
+        {
+            var projects = solutionManager.GetNuGetProjects().OfType<BuildIntegratedNuGetProject>().ToList();
+
+            return await GetParentProjectsInClosure(projects, target);
+        }
+
+        /// <summary>
+        /// Find the list of parent projects which directly or indirectly reference the child project.
+        /// </summary>
+        public static async Task<IReadOnlyList<BuildIntegratedNuGetProject>> GetParentProjectsInClosure(
+            IReadOnlyList<BuildIntegratedNuGetProject> projects,
+            BuildIntegratedNuGetProject target)
+        {
+            if (projects == null)
+            {
+                throw new ArgumentNullException(nameof(projects));
+            }
+
+            if (target == null)
+            {
+                throw new ArgumentNullException(nameof(target));
+            }
+
+            var parents = new HashSet<BuildIntegratedNuGetProject>();
+
+            var targetProjectJson = Path.GetFullPath(target.JsonConfigPath);
+
+            foreach (var project in projects)
+            {
+                // do not count the target as a parent
+                if (!target.Equals(project))
+                {
+                    var closure = await project.GetProjectReferenceClosureAsync();
+
+                    // find all projects which have a child reference matching the same project.json path as the target
+                    if (closure.Any(reference =>
+                        !string.IsNullOrEmpty(reference.PackageSpecPath) &&
+                        string.Equals(targetProjectJson, Path.GetFullPath(reference.PackageSpecPath), StringComparison.OrdinalIgnoreCase)))
+                    {
+                        parents.Add(project);
+                    }
+                }
+            }
+
+            // sort parents by name to make this more deterministic during restores
+            return parents.OrderBy(parent => parent.ProjectName).ToList();
+        }
+
+        /// <summary>
+        /// Returns the lockfile if it exists, otherwise null.
+        /// </summary>
+        private static LockFile GetLockFile(BuildIntegratedNuGetProject project, Logging.ILogger logger)
+        {
+            LockFile lockFile = null;
+
+            var lockFilePath = BuildIntegratedProjectUtility.GetLockFilePath(project.JsonConfigPath);
+
+            if (File.Exists(lockFilePath))
+            {
+                var format = new LockFileFormat();
+
+                // A corrupt lock file will log errors and return null
+                lockFile = format.Read(lockFilePath, logger);
+            }
+
+            return lockFile;
         }
     }
 }

--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -361,10 +361,10 @@ namespace NuGet.PackageManagement
                         NuGetVersion latestVersion = await GetLatestVersionAsync(
                             installedPackage.PackageIdentity.Id,
                             resolutionContext,
-                            primarySources, 
+                            primarySources,
                             token);
 
-                        if (latestVersion != null  && latestVersion > installedPackage.PackageIdentity.Version)
+                        if (latestVersion != null && latestVersion > installedPackage.PackageIdentity.Version)
                         {
                             lowLevelActions.Add(NuGetProjectAction.CreateUninstallProjectAction(installedPackage.PackageIdentity));
                             lowLevelActions.Add(NuGetProjectAction.CreateInstallProjectAction(
@@ -1421,7 +1421,8 @@ namespace NuGet.PackageManagement
                 nuGetProjectActions.First().NuGetProjectActionType,
                 originalLockFile,
                 rawPackageSpec,
-                restoreResult);
+                restoreResult,
+                sources.ToList());
         }
 
         /// <summary>
@@ -1444,9 +1445,13 @@ namespace NuGet.PackageManagement
                 projectAction = await PreviewBuildIntegratedProjectActionsAsync(buildIntegratedProject, nuGetProjectActions, nuGetProjectContext, token);
             }
 
+            var uninstallOnly = projectAction.GetProjectActions().All(action => action.NuGetProjectActionType == NuGetProjectActionType.Uninstall);
+
             var restoreResult = projectAction.RestoreResult;
 
-            if (restoreResult.Success)
+            // Avoid committing the changes if the restore did not succeed
+            // For uninstalls continue even if the restore failed to avoid blocking the user
+            if (restoreResult.Success || uninstallOnly)
             {
                 // Write out project.json
                 // This can be replaced with the PackageSpec writer once it has been added to the library
@@ -1476,7 +1481,7 @@ namespace NuGet.PackageManagement
                     }
                     else
                     {
-                        // uninstall
+                        // uninstall 
                         nuGetProjectContext.Log(
                             ProjectManagement.MessageLevel.Info,
                             Strings.SuccessfullyUninstalled,
@@ -1499,6 +1504,20 @@ namespace NuGet.PackageManagement
                         var packagePath = BuildIntegratedProjectUtility.GetPackagePathFromGlobalSource(package, Settings);
                         await buildIntegratedProject.ExecuteInitScriptAsync(package, nuGetProjectContext, false);
                     }
+                }
+
+                // Restore parent projects. These will be updated to include the transitive changes.
+                var parents = await BuildIntegratedRestoreUtility.GetParentProjectsInClosure(SolutionManager, buildIntegratedProject);
+
+                foreach (var parent in parents)
+                {
+                    // Restore and commit the lock file to disk regardless of the result
+                    var parentResult = await BuildIntegratedRestoreUtility.RestoreAsync(
+                        parent,
+                        logger,
+                        projectAction.Sources,
+                        Settings,
+                        token);
                 }
             }
             else

--- a/test/Test.Utility/TestSolutionManager.cs
+++ b/test/Test.Utility/TestSolutionManager.cs
@@ -15,7 +15,7 @@ namespace Test.Utility
 {
     public class TestSolutionManager : ISolutionManager
     {
-        private List<NuGetProject> NuGetProjects { get; }
+        public List<NuGetProject> NuGetProjects { get; set; }
 
         public string SolutionDirectory { get; }
 


### PR DESCRIPTION
This fix adds support for restoring parent projects to pull in transitive changes when a package install/uninstall/update occurs. If a rollback occurs the parent projects are left alone. Failures when restoring parent projects will not cause a rollback, the user will need to fix these themselves.

A couple additional fixes were added that go along with this:
Uninstalls will no longer rollback
The existing lock file is passed into the restore request to support locked=true

//cc @deepakaravindr @yishaigalatzer 
