### PR TITLE
Adding ILogger to GetProjectReferenceClosureAsync 

### DIFF
--- a/pack.ps1
+++ b/pack.ps1
@@ -32,9 +32,11 @@ function Pack(
     Write-Host "Package version: $version" -ForegroundColor Cyan
 
     # create the output folder
-    if ((Test-Path nupkgs) -eq 0) {
-        New-Item -ItemType directory -Path nupkgs | Out-Null
+    if ((Test-Path nupkgs) -eq 1) {
+        Remove-Item -Path nupkgs | Out-Null
     }
+
+    New-Item -ItemType directory -Path nupkgs | Out-Null
 
     # Pack
 	Write-Host "Project path is $ProjectPath"

--- a/src/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -160,6 +160,6 @@
     <None Include="project.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\NuGet.MsBuild.Integration\build\Microsoft.NuGet.targets" />
+  <Import Project="..\..\build\common.targets" />
   <Import Project="..\..\build\sign.targets" />
 </Project>

--- a/src/NuGet.CommandLine/Properties/AssemblyInfo.cs
+++ b/src/NuGet.CommandLine/Properties/AssemblyInfo.cs
@@ -11,14 +11,3 @@ using System.Runtime.InteropServices;
 
 [assembly: AssemblyTitle("NuGet Command Line")]
 [assembly: AssemblyDescription("NuGet Command Line")]
-
-// Common attributes
-
-[assembly: AssemblyCompany(".NET Foundation")]
-[assembly: AssemblyProduct("NuGet")]
-[assembly: AssemblyCopyright("\x00a9 .NET Foundation. All rights reserved.")]
-[assembly: NeutralResourcesLanguage("en-US")]
-[assembly: CLSCompliant(false)]
-[assembly: ComVisible(false)]
-[assembly: AssemblyVersion("3.1.0.0")]
-[assembly: AssemblyInformationalVersion("3.1.0")]

--- a/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -76,7 +76,7 @@ namespace NuGet.PackageManagement
             request.ExistingLockFile = GetLockFile(project, logger);
 
             // Find the full closure of project.json files and referenced projects
-            var projectReferences = await project.GetProjectReferenceClosureAsync();
+            var projectReferences = await project.GetProjectReferenceClosureAsync(logger);
             request.ExternalProjects = projectReferences
                 .Where(reference => !string.IsNullOrEmpty(reference.PackageSpecPath))
                 .Select(reference => BuildIntegratedProjectUtility.ConvertProjectReference(reference))

--- a/src/ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
+++ b/src/ProjectManagement/Projects/BuildIntegratedNuGetProject.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
+using NuGet.Logging;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectModel;
@@ -100,7 +101,16 @@ namespace NuGet.ProjectManagement.Projects
         /// <summary>
         /// Retrieve the full closure of project to project references.
         /// </summary>
-        public virtual Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync()
+        public Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync()
+        {
+            return GetProjectReferenceClosureAsync(NullLogger.Instance);
+        }
+
+        /// <summary>
+        /// Retrieve the full closure of project to project references.
+        /// Warnings and errors encountered will be logged.
+        /// </summary>
+        public virtual Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync(ILogger logger)
         {
             // This cannot be resolved with DTE currently, it is overridden at a higher level
             return Task.FromResult<IReadOnlyList<BuildIntegratedProjectReference>>(

--- a/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -92,7 +92,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\packages\NuGet.MsBuild.Integration\build\Microsoft.NuGet.targets" />
+  <Import Project="..\..\build\common.targets" />
   <Import Project="..\..\build\test.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>

--- a/test/NuGet.CommandLine.Test/Properties/AssemblyInfo.cs
+++ b/test/NuGet.CommandLine.Test/Properties/AssemblyInfo.cs
@@ -1,5 +1,4 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
@@ -7,30 +6,6 @@ using System.Runtime.InteropServices;
 // associated with an assembly.
 [assembly: AssemblyTitle("NuGet.CommandLine.Test")]
 [assembly: AssemblyDescription("")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
-[assembly: AssemblyProduct("NuGet.CommandLine.Test")]
-[assembly: AssemblyCopyright("Copyright ©  2015")]
-[assembly: AssemblyTrademark("")]
-[assembly: AssemblyCulture("")]
-
-// Setting ComVisible to false makes the types in this assembly not visible 
-// to COM components.  If you need to access a type in this assembly from 
-// COM, set the ComVisible attribute to true on that type.
-[assembly: ComVisible(false)]
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("33294bb8-5144-4363-b02c-332f6d94c1c1")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version 
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers 
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
+++ b/test/PackageManagement.Test/BuildIntegratedRestoreUtilityTests.cs
@@ -6,7 +6,6 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
-using NuGet.Configuration;
 using NuGet.Frameworks;
 using NuGet.PackageManagement;
 using NuGet.Packaging;
@@ -814,7 +813,7 @@ namespace NuGet.Test
                 InternalMetadata.Add(NuGetProjectMetadataKeys.UniqueName, msbuildProjectSystem.ProjectName);
             }
 
-            public override Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync()
+            public override Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync(NuGet.Logging.ILogger logger)
             {
                 return Task.FromResult(ProjectClosure);
             }

--- a/test/PackageManagement.Test/BuildIntegratedTests.cs
+++ b/test/PackageManagement.Test/BuildIntegratedTests.cs
@@ -1038,7 +1038,7 @@ namespace NuGet.Test
                 return base.ExecuteInitScriptAsync(identity, packageInstallPath, projectContext, throwOnFailure);
             }
 
-            public override Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync()
+            public override Task<IReadOnlyList<BuildIntegratedProjectReference>> GetProjectReferenceClosureAsync(Logging.ILogger logger)
             {
                 return Task.FromResult<IReadOnlyList<BuildIntegratedProjectReference>>(ProjectReferences);
             }

--- a/test/PackageManagement.Test/project.json
+++ b/test/PackageManagement.Test/project.json
@@ -1,6 +1,7 @@
 {
     "dependencies": {
-        "xunit.runner.visualstudio": "2.0.0"
+      "xunit.runner.visualstudio": "2.0.0",
+      "NuGet.Logging": "3.1.2-*"
     },
     "frameworks": {
         "net45": {}


### PR DESCRIPTION
This contains a signature change to GetProjectReferenceClosureAsync to pass in ILogger
Build fixes

//cc @deepakaravindr 
