### PR TITLE
Console write thread safety

### DIFF
--- a/src/NuGet.CommandLine/Common/Console.cs
+++ b/src/NuGet.CommandLine/Common/Console.cs
@@ -8,6 +8,12 @@ namespace NuGet.Common
 {
     public class Console : IConsole
     {
+        /// <summary>
+        /// All operations writing to Out should be wrapped in a lock to 
+        /// avoid color mismatches during parallel operations.
+        /// </summary>
+        private readonly static object _writerLock = new object();
+
         public Console()
         {
             // setup CancelKeyPress handler so that the console colors are
@@ -78,46 +84,67 @@ namespace NuGet.Common
 
         public void Write(object value)
         {
-            Out.Write(value);
+            lock (_writerLock)
+            {
+                Out.Write(value);
+            }
         }
 
         public void Write(string value)
         {
-            Out.Write(value);
+            lock (_writerLock)
+            {
+                Out.Write(value);
+            }
         }
 
         public void Write(string format, params object[] args)
         {
-            if (args == null || !args.Any())
+            lock (_writerLock)
             {
-                // Don't try to format strings that do not have arguments. We end up throwing if the original string was not meant to be a format token 
-                // and contained braces (for instance html)
-                Out.Write(format);
-            }
-            else
-            {
-                Out.Write(format, args);
+                if (args == null || !args.Any())
+                {
+                    // Don't try to format strings that do not have arguments. We end up throwing if the original string was not meant to be a format token 
+                    // and contained braces (for instance html)
+                    Out.Write(format);
+                }
+                else
+                {
+                    Out.Write(format, args);
+                }
             }
         }
 
         public void WriteLine()
         {
-            Out.WriteLine();
+            lock (_writerLock)
+            {
+                Out.WriteLine();
+            }
         }
 
         public void WriteLine(object value)
         {
-            Out.WriteLine(value);
+            lock (_writerLock)
+            {
+                Out.WriteLine(value);
+            }
         }
 
         public void WriteLine(string value)
         {
-            Out.WriteLine(value);
+            lock (_writerLock)
+            {
+                Out.WriteLine(value);
+            }
         }
 
         public void WriteLine(string format, params object[] args)
         {
-            Out.WriteLine(format, args);
+            lock (_writerLock)
+            {
+                Out.WriteLine(format, args);
+            }
         }
 
         public void WriteError(object value)
@@ -166,24 +193,27 @@ namespace NuGet.Common
 
         private static void WriteColor(TextWriter writer, ConsoleColor color, string value, params object[] args)
         {
-            var currentColor = System.Console.ForegroundColor;
-            try
+            lock (_writerLock)
             {
-                currentColor = System.Console.ForegroundColor;
-                System.Console.ForegroundColor = color;
-                if (args == null || !args.Any())
+                var currentColor = System.Console.ForegroundColor;
+                try
                 {
-                    // If it doesn't look like something that needs to be formatted, don't format it.
-                    writer.WriteLine(value);
+                    currentColor = System.Console.ForegroundColor;
+                    System.Console.ForegroundColor = color;
+                    if (args == null || !args.Any())
+                    {
+                        // If it doesn't look like something that needs to be formatted, don't format it.
+                        writer.WriteLine(value);
+                    }
+                    else
+                    {
+                        writer.WriteLine(value, args);
+                    }
                 }
-                else
+                finally
                 {
-                    writer.WriteLine(value, args);
+                    System.Console.ForegroundColor = currentColor;
                 }
-            }
-            finally
-            {
-                System.Console.ForegroundColor = currentColor;
             }
         }
 
@@ -199,31 +229,36 @@ namespace NuGet.Common
                 maxWidth = maxWidth - startIndex - 1;
             }
 
-            while (text.Length > 0)
+            lock (_writerLock)
             {
-                // Trim whitespace at the beginning
-                text = text.TrimStart();
-                // Calculate the number of chars to print based on the width of the System.Console
-                int length = Math.Min(text.Length, maxWidth);
-
-                string content;
-
-                // Text we can print without overflowing the System.Console, excluding new line characters.
-                int newLineIndex = text.IndexOf(Environment.NewLine, 0, length, StringComparison.OrdinalIgnoreCase);
-                if (newLineIndex > -1)
+                while (text.Length > 0)
                 {
-                    content = text.Substring(0, newLineIndex);
-                }
-                else
-                {
-                    content = text.Substring(0, length);
-                }
+                    // Trim whitespace at the beginning
+                    text = text.TrimStart();
+                    // Calculate the number of chars to print based on the width of the System.Console
+                    int length = Math.Min(text.Length, maxWidth);
 
-                int leftPadding = startIndex + content.Length - CursorLeft;
-                // Print it with the correct padding
-                Out.WriteLine((leftPadding > 0) ? content.PadLeft(leftPadding) : content);
-                // Get the next substring to be printed
-                text = text.Substring(content.Length);
+                    string content;
+
+                    // Text we can print without overflowing the System.Console, excluding new line characters.
+                    int newLineIndex = text.IndexOf(Environment.NewLine, 0, length, StringComparison.OrdinalIgnoreCase);
+                    if (newLineIndex > -1)
+                    {
+                        content = text.Substring(0, newLineIndex);
+                    }
+                    else
+                    {
+                        content = text.Substring(0, length);
+                    }
+
+                    int leftPadding = startIndex + content.Length - CursorLeft;
+
+                    // Print it with the correct padding
+                    Out.WriteLine((leftPadding > 0) ? content.PadLeft(leftPadding) : content);
+
+                    // Get the next substring to be printed
+                    text = text.Substring(content.Length);
+                }
             }
         }
 


### PR DESCRIPTION
This change adds a lock around writes to Console's Out to ensure that only the intended text is colored during WriteColor.

https://github.com/NuGet/Home/issues/1037

//cc @deepakaravindr @feiling @zhili1208 
