### PR TITLE
Fixes https://github.com/NuGet/Home/issues/1115

### DIFF
--- a/src/NuGet.CommandLine/Commands/PushCommand.cs
+++ b/src/NuGet.CommandLine/Commands/PushCommand.cs
@@ -137,14 +137,7 @@ namespace NuGet.CommandLine
             // Push the package to the server
             IPackage package;
             var sourceUri = new Uri(source);
-            if (sourceUri.IsFile)
-            {
-                package = new OptimizedZipPackage(packageToPush);
-            }
-            else
-            {
-                package = new PushLocalPackage(packageToPush);
-            }
+            package = new OptimizedZipPackage(packageToPush);
 
             string sourceName = CommandLineUtility.GetSourceDisplayName(source);
             Console.WriteLine(LocalizedResourceManager.GetString("PushCommandPushingPackage"), package.GetFullName(), sourceName);
@@ -235,36 +228,6 @@ namespace NuGet.CommandLine
             else
             {
                 return false;
-            }
-        }
-
-        private class PushLocalPackage : LocalPackage
-        {
-            private readonly string _filePath;
-
-            public PushLocalPackage(string filePath)
-            {
-                _filePath = filePath;
-            }
-
-            public override void ExtractContents(IFileSystem fileSystem, string extractPath)
-            {
-                throw new NotSupportedException();
-            }
-
-            public override Stream GetStream()
-            {
-                return File.OpenRead(_filePath);
-            }
-
-            protected override IEnumerable<IPackageAssemblyReference> GetAssemblyReferencesCore()
-            {
-                throw new NotSupportedException();
-            }
-
-            protected override IEnumerable<IPackageFile> GetFilesBase()
-            {
-                throw new NotSupportedException();
             }
         }
     }


### PR DESCRIPTION
Using the same code as in 2.8.*. This is not very efficient since it will
(effectively) extract the package to get the full name.
But, trying to make sure that there is no difference between
old and new NuGet.exe

@yishaigalatzer @pranavkm @emgarten @feiling @zhili1208
