### PR TITLE
Changing the mock server to use port reserver insted of hard ports

### DIFF
--- a/src/NuGet.CommandLine/Commands/Command.cs
+++ b/src/NuGet.CommandLine/Commands/Command.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NuGet.Common;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.CommandLine
 {
@@ -110,6 +111,7 @@ namespace NuGet.CommandLine
                 SourceProvider = PackageSourceBuilder.CreateSourceProvider(Settings);
                 SetDefaultCredentialProvider();
                 RepositoryFactory = new CommandLineRepositoryFactory(Console);
+                UserAgent.UserAgentString = UserAgent.CreateUserAgentString(CommandLineConstants.UserAgent);
 
                 ExecuteCommandAsync().Wait();
             }

--- a/src/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -13,6 +13,7 @@ using Microsoft.Build.Execution;
 using Microsoft.Build.Framework;
 using Microsoft.Build.Logging;
 using NuGet.Common;
+using NuGet.Configuration;
 
 namespace NuGet.CommandLine
 {
@@ -21,7 +22,7 @@ namespace NuGet.CommandLine
     {
         private readonly Project _project;
         private Logging.ILogger _logger;
-        private ISettings _settings;
+        private Configuration.ISettings _settings;
 
         // Files we want to always exclude from the resulting package
         private static readonly HashSet<string> _excludeFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
@@ -47,7 +48,7 @@ namespace NuGet.CommandLine
         private const string TransformFileExtension = ".transform";
 
         [Import]
-        public IMachineWideSettings MachineWideSettings { get; set; }
+        public Configuration.IMachineWideSettings MachineWideSettings { get; set; }
 
         public ProjectFactory(string path, IDictionary<string, string> projectProperties)
             : this(new Project(path, projectProperties, null))
@@ -69,14 +70,14 @@ namespace NuGet.CommandLine
             }
         }
 
-        private ISettings DefaultSettings
+        private Configuration.ISettings DefaultSettings
         {
             get
             {
                 if (null == _settings)
                 {
-                    _settings = Settings.LoadDefaultSettings(
-                        new PhysicalFileSystem(_project.DirectoryPath),
+                    _settings = Configuration.Settings.LoadDefaultSettings(
+                        _project.DirectoryPath,
                         null,
                         MachineWideSettings);
                 }
@@ -751,7 +752,7 @@ namespace NuGet.CommandLine
         private IPackageRepository GetPackagesRepository()
         {
             string solutionDir = GetSolutionDir();
-            string defaultValue = DefaultSettings.GetRepositoryPath();
+            string defaultValue = SettingsUtility.GetRepositoryPath(DefaultSettings);
 
             string target = null;
             if (!String.IsNullOrEmpty(solutionDir))

--- a/src/NuGet.CommandLine/Common/CommandLineRepositoryFactory.cs
+++ b/src/NuGet.CommandLine/Common/CommandLineRepositoryFactory.cs
@@ -5,8 +5,6 @@ namespace NuGet.Common
 {
     public class CommandLineRepositoryFactory : PackageRepositoryFactory
     {
-        public static readonly string UserAgent = "NuGet Command Line";
-
         private readonly IConsole _console;
 
         public CommandLineRepositoryFactory(IConsole console)

--- a/test/NuGet.CommandLine.Test/CommandRunner.cs
+++ b/test/NuGet.CommandLine.Test/CommandRunner.cs
@@ -12,7 +12,12 @@ namespace NuGet.CommandLine.Test
     {
         // Item1 of the returned tuple is the exit code. Item2 is the standard output, and Item3 
         // is the error output.
-        public static Tuple<int, string, string> Run(string process, string workingDirectory, string arguments, bool waitForExit, int timeOutInMilliseconds = 600000000,
+        public static Tuple<int, string, string> Run(
+            string process, 
+            string workingDirectory, 
+            string arguments, 
+            bool waitForExit, 
+            int timeOutInMilliseconds = 60000,
            Action<StreamWriter> inputAction = null)
         {
             string result = String.Empty;

--- a/test/NuGet.CommandLine.Test/CommandRunner.cs
+++ b/test/NuGet.CommandLine.Test/CommandRunner.cs
@@ -12,7 +12,7 @@ namespace NuGet.CommandLine.Test
     {
         // Item1 of the returned tuple is the exit code. Item2 is the standard output, and Item3 
         // is the error output.
-        public static Tuple<int, string, string> Run(string process, string workingDirectory, string arguments, bool waitForExit, int timeOutInMilliseconds = 60000,
+        public static Tuple<int, string, string> Run(string process, string workingDirectory, string arguments, bool waitForExit, int timeOutInMilliseconds = 600000000,
            Action<StreamWriter> inputAction = null)
         {
             string result = String.Empty;

--- a/test/NuGet.CommandLine.Test/MockServer.cs
+++ b/test/NuGet.CommandLine.Test/MockServer.cs
@@ -28,7 +28,7 @@ namespace NuGet.CommandLine.Test
         /// </summary>
         public MockServer()
         {
-            this._portReserver = new PortReserver();
+            _portReserver = new PortReserver();
 
             _listener = new HttpListener();
             _listener.Prefixes.Add(_portReserver.BaseUri);
@@ -289,7 +289,7 @@ namespace NuGet.CommandLine.Test
         public string ToODataFeed(IEnumerable<IPackage> packages, string title)
         {
             string nsAtom = "http://www.w3.org/2005/Atom";
-            var id = string.Format(CultureInfo.InvariantCulture, "{0}{1}", this.Uri, title);
+            var id = string.Format(CultureInfo.InvariantCulture, "{0}{1}", Uri, title);
             XDocument doc = new XDocument(
                 new XElement(XName.Get("feed", nsAtom),
                     new XElement(XName.Get("id", nsAtom), id),
@@ -315,11 +315,11 @@ namespace NuGet.CommandLine.Test
             string nsMetadata = "http://schemas.microsoft.com/ado/2007/08/dataservices/metadata";
             string downloadUrl = string.Format(
                 CultureInfo.InvariantCulture,
-                "{0}package/{1}/{2}", this.Uri, package.Id, package.Version);
+                "{0}package/{1}/{2}", Uri, package.Id, package.Version);
             string entryId = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}Packages(Id='{1}',Version='{2}')",
-                this.Uri, package.Id, package.Version);
+                Uri, package.Id, package.Version);
 
             var entry = new XElement(XName.Get("entry", nsAtom),
                 new XAttribute(XNamespace.Xmlns + "d", nsDataService.ToString()),
@@ -351,10 +351,10 @@ namespace NuGet.CommandLine.Test
                 if (disposing)
                 {
                     // Closing the http listener
-                    this.Stop();
+                    Stop();
 
                     // Disposing the PortReserver
-                    this._portReserver.Dispose();
+                    _portReserver.Dispose();
                 }
                 
                 _disposedValue = true;

--- a/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -69,6 +69,7 @@
     <Compile Include="NuGetPackCommandTest.cs" />
     <Compile Include="NuGetPushCommandTest.cs" />
     <Compile Include="NuGetRestoreCommandTest.cs" />
+    <Compile Include="PortReserver.cs" />
     <Compile Include="RestoreProjectJsonTest.cs" />
     <Compile Include="NuGetSourcesCommandTest.cs" />
     <Compile Include="PackageCreator.cs" />

--- a/test/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetDeleteCommandTest.cs
@@ -85,33 +85,33 @@ namespace NuGet.CommandLine.Test
         {
             var nugetexe = Util.GetNuGetExePath();
             var tempPath = Path.GetTempPath();
-            var mockServerEndPoint = "http://localhost:9012/";
 
             // Arrange
-            var server = new MockServer(mockServerEndPoint);
-            server.Start();
-            bool deleteRequestIsCalled = false;
-
-            server.Delete.Add("/nuget/testPackage1/1.1", request =>
+            using (var server = new MockServer())
             {
-                deleteRequestIsCalled = true;
-                return HttpStatusCode.OK;
-            });
+                server.Start();
+                bool deleteRequestIsCalled = false;
 
-            // Act
-            string[] args = new string[] {
+                server.Delete.Add("/nuget/testPackage1/1.1", request =>
+                {
+                    deleteRequestIsCalled = true;
+                    return HttpStatusCode.OK;
+                });
+
+                // Act
+                string[] args = new string[] {
                     "delete", "testPackage1", "1.1.0",
-                    "-Source", mockServerEndPoint + "nuget", "-NonInteractive" };
-            var r = CommandRunner.Run(
-                nugetexe,
-                Directory.GetCurrentDirectory(),
-                string.Join(" ", args),
-                waitForExit: true);
-            server.Stop();
+                    "-Source", server.Uri + "nuget", "-NonInteractive" };
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    Directory.GetCurrentDirectory(),
+                    string.Join(" ", args),
+                    waitForExit: true);
 
-            // Assert
-            Assert.Equal(0, r.Item1);
-            Assert.True(deleteRequestIsCalled);
+                // Assert
+                Assert.Equal(0, r.Item1);
+                Assert.True(deleteRequestIsCalled);
+            }            
         }
     }
 }

--- a/test/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -416,7 +416,6 @@ namespace NuGet.CommandLine.Test
                         workingDirectory,
                         args,
                         waitForExit: true);
-                    server.Stop();
 
                     // Assert
                     Assert.Equal(0, r1.Item1);
@@ -467,7 +466,6 @@ namespace NuGet.CommandLine.Test
                         workingDirectory,
                         args,
                         waitForExit: true);
-                    server.Stop();
 
                     // Assert
                     Assert.Equal(0, r1.Item1);
@@ -542,7 +540,6 @@ namespace NuGet.CommandLine.Test
                         workingDirectory,
                         args,
                         waitForExit: true);
-                    server.Stop();
 
                     // Assert
                     Assert.Equal(0, r1.Item1);
@@ -600,7 +597,6 @@ namespace NuGet.CommandLine.Test
                         workingDirectory,
                         args,
                         waitForExit: true);
-                    server.Stop();
 
                     // Assert
                     Assert.Equal(1, r1.Item1);
@@ -687,7 +683,6 @@ namespace NuGet.CommandLine.Test
                         workingDirectory,
                         args,
                         waitForExit: true);
-                    server.Stop();
 
                     // Assert
                     Assert.True(0 == r1.Item1, r1.Item2 + " " + r1.Item3);

--- a/test/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetPackCommandTest.cs
@@ -594,7 +594,7 @@ namespace Proj2
         // Test that when creating a package from project A, the output of a referenced project
         // will be added to the same target framework folder as A, regardless of the target
         // framework of the referenced project.
-        [Fact(Skip = "This scenario fails and is tracked by an issue")]
+        [Fact]
         public void PackCommand_ReferencedProjectWithDifferentTarget()
         {
             var nugetexe = Util.GetNuGetExePath();

--- a/test/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -402,14 +402,14 @@ namespace NuGet.CommandLine.Test
                     server.Get.Add("/nuget", r =>
                     {
                         var h = r.Headers["Authorization"];
-                        var credential = System.Text.Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
+                        var credential = Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
                         credentialForGetRequest.Add(credential);
                         return HttpStatusCode.OK;
                     });
                     server.Put.Add("/nuget", r => new Action<HttpListenerResponse>(res =>
                     {
                         var h = r.Headers["Authorization"];
-                        var credential = System.Text.Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
+                        var credential = Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
                         credentialForPutRequest.Add(credential);
 
                         if (credential.Equals("testuser:testpassword", StringComparison.OrdinalIgnoreCase))

--- a/test/NuGet.CommandLine.Test/PortReserver.cs
+++ b/test/NuGet.CommandLine.Test/PortReserver.cs
@@ -1,0 +1,135 @@
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.Linq;
+using System.Net;
+using System.Net.NetworkInformation;
+using System.Threading;
+
+namespace NuGet.CommandLine.Test
+{
+    /// <summary>
+    /// This class allocates ports while ensuring that:
+    /// 1. Ports that are permanently taken (or taken for the duration of the test) are not being attempted to be used.
+    /// 2. Ports are not shared across different tests (but you can allocate two different ports in the same test).
+    /// 
+    /// Gotcha: If another application grabs a port during the test, we have a race condition.
+    /// </summary>
+    [DebuggerDisplay("Port: {PortNumber}, Port count for this app domain: {_appDomainOwnedPorts.Count}")]
+    public class PortReserver : IDisposable
+    {
+        private Mutex _portMutex;
+
+        // We use this list to hold on to all the ports used because the Mutex will be blown through on the same thread.
+        // Theoretically we can do a thread local hashset, but that makes dispose thread dependant, or requires more complicated concurrency checks.
+        // Since practically there is no perf issue or concern here, this keeps the code the simplest possible.
+        private static HashSet<int> _appDomainOwnedPorts = new HashSet<int>();
+
+        public int PortNumber
+        {
+            get;
+            private set;
+        }
+
+        public PortReserver(int basePort = 50231)
+        {
+            if (basePort <= 0)
+            {
+                throw new InvalidOperationException();
+            }
+
+            // Grab a cross appdomain/cross process/cross thread lock, to ensure only one port is reserved at a time.
+            using (Mutex mutex = GetGlobalMutex())
+            {
+                try
+                {
+                    int port = basePort - 1;
+
+                    while (true)
+                    {
+                        port++;
+
+                        if (port > 65535)
+                        {
+                            throw new InvalidOperationException("Exceeded port range");
+                        }
+
+                        // AppDomainOwnedPorts check enables reserving two ports from the same thread in sequence.
+                        // ListUsedTCPPort prevents port contention with other apps.
+                        if (_appDomainOwnedPorts.Contains(port) ||
+                            ListUsedTCPPort().Any(endPoint => endPoint.Port == port))
+                        {
+                            continue;
+                        }
+
+                        string mutexName = "NuGet-Port-" + port.ToString(CultureInfo.InvariantCulture); // Create a well known mutex
+                        _portMutex = new Mutex(initiallyOwned: false, name: mutexName);
+
+                        // If no one else is using this port grab it.
+                        if (_portMutex.WaitOne(millisecondsTimeout: 0))
+                        {
+                            break;
+                        }
+
+                        // dispose this Mutex since the port it represents is not available.
+                        _portMutex.Dispose();
+                        _portMutex = null;
+                    }
+
+                    PortNumber = port;
+                    _appDomainOwnedPorts.Add(port);
+                }
+                finally
+                {
+                    mutex.ReleaseMutex();
+                }
+            }
+        }
+
+        public string BaseUri
+        {
+            get
+            {
+                return String.Format(CultureInfo.InvariantCulture, "http://localhost:{0}/", PortNumber);
+            }
+        }
+
+        public void Dispose()
+        {
+            if (PortNumber == -1)
+            {
+                // Object already disposed
+                return;
+            }
+
+            using (Mutex mutex = GetGlobalMutex())
+            {
+                _portMutex.Dispose();
+                _appDomainOwnedPorts.Remove(PortNumber);
+                PortNumber = -1;
+            }
+        }
+
+        private static Mutex GetGlobalMutex()
+        {
+            Mutex mutex = new Mutex(initiallyOwned: false, name: "NuGet-RandomPortAcquisition");
+            if (!mutex.WaitOne(30000))
+            {
+                throw new InvalidOperationException();
+            }
+
+            return mutex;
+        }
+
+        private static IPEndPoint[] ListUsedTCPPort()
+        {
+            var usedPort = new HashSet<int>();
+            IPGlobalProperties ipGlobalProperties = IPGlobalProperties.GetIPGlobalProperties();
+
+            return ipGlobalProperties.GetActiveTcpListeners();
+        }
+    }
+}

--- a/test/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.CommandLine.Test/Util.cs
@@ -149,9 +149,9 @@ namespace NuGet.CommandLine.Test
         /// <summary>
         /// Creates a mock server that contains the specified list of packages
         /// </summary>
-        public static MockServer CreateMockServer(string mockServerEndPoint, IList<IPackage> packages)
+        public static MockServer CreateMockServer(IList<IPackage> packages)
         {
-            var server = new MockServer(mockServerEndPoint);
+            var server = new MockServer();
 
             server.Get.Add("/nuget/$metadata", r =>
                    MockServerResource.NuGetV2APIMetadata);


### PR DESCRIPTION
Changing the Server mock to used port reserver instead of hard coding the port in the tests, This change also enable executing this tests in parallel as the port reserver making sure not to allocate reserved ports to other tests.

nuget/home#1050

@deepakaravindr @yishaigalatzer @emgarten @feiling 
