### PR TITLE
Showing user-friendly message when packages.config or solution file is invalid

### DIFF
--- a/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Xml;
 using System.Xml.Linq;
 using NuGet.Configuration;
 using NuGet.Packaging;
@@ -78,6 +79,21 @@ namespace NuGet.CommandLine
         {
             if (File.Exists(projectConfigFilePath))
             {
+                try
+                {
+                    var xDocument = XDocument.Load(projectConfigFilePath);
+                }
+                catch (XmlException ex)
+                {
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString("Error_PackagesConfigParseError"),
+                        projectConfigFilePath,
+                        ex.Message);
+
+                    throw new CommandLineException(message);
+                }
+
                 var reader = new PackagesConfigReader(XDocument.Load(projectConfigFilePath));
                 return reader.GetPackages();
             }

--- a/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -82,6 +82,8 @@ namespace NuGet.CommandLine
                 try
                 {
                     var xDocument = XDocument.Load(projectConfigFilePath);
+                    var reader = new PackagesConfigReader(XDocument.Load(projectConfigFilePath));
+                    return reader.GetPackages();
                 }
                 catch (XmlException ex)
                 {
@@ -93,9 +95,6 @@ namespace NuGet.CommandLine
 
                     throw new CommandLineException(message);
                 }
-
-                var reader = new PackagesConfigReader(XDocument.Load(projectConfigFilePath));
-                return reader.GetPackages();
             }
 
             return Enumerable.Empty<Packaging.PackageReference>();

--- a/src/NuGet.CommandLine/Common/Solution.cs
+++ b/src/NuGet.CommandLine/Common/Solution.cs
@@ -27,7 +27,14 @@ namespace NuGet.Common
             using (var streamReader = new StreamReader(solutionFileName))
             {
                 _solutionReaderProperty.SetValue(solutionParser, streamReader, index: null);
-                _parseSolutionMethod.Invoke(solutionParser, parameters: null);
+                try
+                {
+                    _parseSolutionMethod.Invoke(solutionParser, parameters: null);
+                }
+                catch (TargetInvocationException ex)
+                {
+                    throw ex.InnerException ?? ex;
+                }
             }
             var projects = new List<ProjectInSolution>();
             foreach (var proj in (object[])_projectsProperty.GetValue(solutionParser, index: null))

--- a/src/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.CommandLine/MsBuildUtility.cs
@@ -107,10 +107,23 @@ namespace NuGet.CommandLine
 
         public static IEnumerable<string> GetAllProjectFileNames(string solutionFile)
         {
-            var solution = new Solution(solutionFile);
-            var solutionDirectory = Path.GetDirectoryName(solutionFile);
-            return solution.Projects.Where(project => !project.IsSolutionFolder)
-                .Select(project => Path.Combine(solutionDirectory, project.RelativePath));
+            try
+            {
+                var solution = new Solution(solutionFile);
+                var solutionDirectory = Path.GetDirectoryName(solutionFile);
+                return solution.Projects.Where(project => !project.IsSolutionFolder)
+                    .Select(project => Path.Combine(solutionDirectory, project.RelativePath));
+            }
+            catch (Exception ex)
+            {
+                var message = string.Format(
+                    CultureInfo.CurrentCulture,
+                    LocalizedResourceManager.GetString("Error_SolutionFileParseError"),
+                    solutionFile,
+                    ex.Message);
+
+                throw new CommandLineException(message);
+            }
         }
     }
 }

--- a/src/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2986,6 +2986,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error parsing packages.config file at {0}: {1}.
+        /// </summary>
+        public static string Error_PackagesConfigParseError {
+            get {
+                return ResourceManager.GetString("Error_PackagesConfigParseError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Error occurred when processing file &apos;{0}&apos;: {1}.
         /// </summary>
         public static string Error_ProcessingNuspecFile {
@@ -3234,6 +3243,15 @@ namespace NuGet.CommandLine {
         public static string Error_SettingsIsNull_trk {
             get {
                 return ResourceManager.GetString("Error_SettingsIsNull_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Error parsing solution file at {0}: {1}.
+        /// </summary>
+        public static string Error_SolutionFileParseError {
+            get {
+                return ResourceManager.GetString("Error_SolutionFileParseError", resourceCulture);
             }
         }
         

--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -6037,4 +6037,10 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>'globalPackagesFolder' setting is a relative path. To determine full path, please specify either -SolutionDirectory or a solution file as a parameter. To ignore 'globalPackagesFolder' setting, specify -PackagesDirectory.</value>
     <comment>Please do not localize 'globalPackagesFolder', -SolutionDirectory or -PackagesDirectory</comment>
   </data>
+  <data name="Error_PackagesConfigParseError" xml:space="preserve">
+    <value>Error parsing packages.config file at {0}: {1}</value>
+  </data>
+  <data name="Error_SolutionFileParseError" xml:space="preserve">
+    <value>Error parsing solution file at {0}: {1}</value>
+  </data>
 </root>


### PR DESCRIPTION
instead of simply showing the message from the exception

Fixes https://github.com/NuGet/Home/issues/1034

@yishaigalatzer @emgarten @feiling @zhili1208 @pranavkm 
