### PR TITLE
Fix NuGet/Home#213: Restore with WinRT C++ fails

### DIFF
--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -33,8 +33,8 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "RestoreCommandSolutionDirectory")]
         public string SolutionDirectory { get; set; }
 
-        [Option(typeof(NuGetCommand), "RestoreCommandMsBuildPath")]
-        public string MsBuildPath { get; set; }
+        [Option(typeof(NuGetCommand), "CommandMSBuildVersion")]
+        public string MSBuildVersion { get; set; }
 
         [ImportingConstructor]
         public RestoreCommand()
@@ -42,8 +42,13 @@ namespace NuGet.CommandLine
         {
         }
 
+        // The directory that contains msbuild
+        private string _msbuildDirectory;
+
         public override async Task ExecuteCommandAsync()
         {
+            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion);
+
             if (!string.IsNullOrEmpty(PackagesDirectory))
             {
                 PackagesDirectory = Path.GetFullPath(PackagesDirectory);
@@ -155,7 +160,7 @@ namespace NuGet.CommandLine
             {
                 // Restore a .csproj or other msbuild project file using the 
                 // file name without the extension as the Id
-                externalProjects = MsBuildUtility.GetProjectReferences(MsBuildPath, projectPath);
+                externalProjects = MsBuildUtility.GetProjectReferences(_msbuildDirectory, projectPath);
 
                 var projectDirectory = Path.GetDirectoryName(Path.GetFullPath(projectPath));
                 projectJsonPath = Path.Combine(projectDirectory, PackageSpec.PackageSpecFileName);
@@ -552,7 +557,7 @@ namespace NuGet.CommandLine
         {
             restoreInputs.DirectoryOfSolutionFile = Path.GetDirectoryName(solutionFileFullPath);
 
-            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath);
+            var projectFiles = MsBuildUtility.GetAllProjectFileNames(solutionFileFullPath, _msbuildDirectory);
             foreach (var projectFile in projectFiles)
             {
                 if (!File.Exists(projectFile))

--- a/src/NuGet.CommandLine/Common/ProjectInSolution.cs
+++ b/src/NuGet.CommandLine/Common/ProjectInSolution.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 using System.Reflection;
 
 namespace NuGet.Common
@@ -8,10 +9,6 @@ namespace NuGet.Common
     /// </summary>
     internal class ProjectInSolution
     {
-        private static readonly Type _projectInSolutionType = GetProjectInSolutionType();
-        private static readonly PropertyInfo _relativePathProperty = GetRelativePathProperty();
-        private static readonly PropertyInfo _projectTypeProperty = GetProjectTypeProperty();
-
         /// <summary>
         /// The path of the project relative to the solution.
         /// </summary>
@@ -20,35 +17,12 @@ namespace NuGet.Common
         /// <summary>
         /// Indicates if the project is a solution folder.
         /// </summary>
-        public bool IsSolutionFolder { get; private set; }        
+        public bool IsSolutionFolder { get; private set; }
 
-        public ProjectInSolution(object solutionProject)
+        public ProjectInSolution(string relativePath, bool isSolutionFolder)
         {
-            string projectType = _projectTypeProperty.GetValue(solutionProject, index: null).ToString();
-            IsSolutionFolder = projectType.Equals("SolutionFolder", StringComparison.OrdinalIgnoreCase);
-            RelativePath = (string)_relativePathProperty.GetValue(solutionProject, index: null);
+            RelativePath = relativePath;
+            IsSolutionFolder = isSolutionFolder;
         }
-
-        private static Type GetProjectInSolutionType()
-        {
-            var assembly = typeof(Microsoft.Build.Construction.ProjectElement).Assembly;
-            var projectInSolutionType = assembly.GetType("Microsoft.Build.Construction.ProjectInSolution");
-            if (projectInSolutionType == null)
-            {
-                throw new CommandLineException(LocalizedResourceManager.GetString("Error_CannotLoadTypeProjectInSolution"));
-            }
-
-            return projectInSolutionType;
-        }
-
-        private static PropertyInfo GetRelativePathProperty()
-        {
-            return _projectInSolutionType.GetProperty("RelativePath", BindingFlags.NonPublic | BindingFlags.Instance);
-        }
-
-        private static PropertyInfo GetProjectTypeProperty()
-        {
-            return _projectInSolutionType.GetProperty("ProjectType", BindingFlags.NonPublic | BindingFlags.Instance);
-        }        
     }
 }

--- a/src/NuGet.CommandLine/Common/Solution.cs
+++ b/src/NuGet.CommandLine/Common/Solution.cs
@@ -1,53 +1,122 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
-using System.Linq;
 using System.Reflection;
 
 namespace NuGet.Common
 {
     /// <summary>
-    /// Represents the solution loaded from a sln file. We use the internal class 
+    /// Represents the solution loaded from a sln file. We use the internal class
     /// Microsoft.Build.Construction.SolutionParser to parse sln files.
     /// </summary>
     internal class Solution
     {
-        private static readonly Type _solutionParserType = GetSolutionParserType();
-        private static readonly PropertyInfo _solutionReaderProperty = GetSolutionReaderProperty();
-        private static readonly MethodInfo _parseSolutionMethod = GetParseSolutionMethod();
-        private static readonly PropertyInfo _projectsProperty = GetProjectsProperty();
-
         public List<ProjectInSolution> Projects { get; private set; }
 
-        public Solution(string solutionFileName)
+        public Solution(string solutionFileName, string msbuildPath)
         {
-            var solutionParser = _solutionParserType.GetConstructor(
-                BindingFlags.Instance | BindingFlags.NonPublic, 
+            if (string.IsNullOrEmpty(msbuildPath))
+            {
+                throw new ArgumentNullException(nameof(msbuildPath));
+            }
+
+            Assembly msbuildAssembly = Assembly.LoadFile(
+                Path.Combine(msbuildPath, "Microsoft.Build.dll"));
+            switch (msbuildAssembly.GetName().Version.Major)
+            {
+                case 4:
+                case 12:
+                    LoadSolutionWithMsbuild4or12(msbuildAssembly, solutionFileName);
+                    break;
+
+                case 14:
+                    LoadSolutionWithMsbuild14(msbuildAssembly, solutionFileName);
+                    break;
+
+                default:
+                    throw new InvalidOperationException(string.Format(
+                        CultureInfo.InvariantCulture,
+                        LocalizedResourceManager.GetString(nameof(NuGet.CommandLine.NuGetResources.Error_UnsupportedMsbuild)),
+                        msbuildAssembly.FullName));
+            }
+        }
+
+        // Load the solution file with msbuild 4 or msbuild 12. In this case,
+        // the internal class SolutionParser is used to parse the solution file
+        private void LoadSolutionWithMsbuild4or12(Assembly msbuildAssembly, string solutionFileName)
+        {
+            Type solutionParserType = msbuildAssembly.GetType(
+                "Microsoft.Build.Construction.SolutionParser",
+                throwOnError: true);
+            PropertyInfo solutionReaderProperty = solutionParserType.GetProperty(
+                "SolutionReader",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            MethodInfo parseSolutionMethod = solutionParserType.GetMethod(
+                "ParseSolution",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            PropertyInfo projectsProperty = solutionParserType.GetProperty(
+                "Projects",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            var solutionParser = solutionParserType.GetConstructor(
+                BindingFlags.Instance | BindingFlags.NonPublic,
                 binder: null, types: Type.EmptyTypes, modifiers: null).Invoke(null);
             using (var streamReader = new StreamReader(solutionFileName))
             {
-                _solutionReaderProperty.SetValue(solutionParser, streamReader, index: null);
+                solutionReaderProperty.SetValue(solutionParser, streamReader, index: null);
                 try
                 {
-                    _parseSolutionMethod.Invoke(solutionParser, parameters: null);
+                    parseSolutionMethod.Invoke(solutionParser, parameters: null);
                 }
                 catch (TargetInvocationException ex)
                 {
                     throw ex.InnerException ?? ex;
                 }
             }
+
+            // load projects
+            Type projectInSolutionType = msbuildAssembly.GetType(
+                "Microsoft.Build.Construction.ProjectInSolution",
+                throwOnError: true);
+            PropertyInfo relativePathProperty = projectInSolutionType.GetProperty(
+                "RelativePath",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            PropertyInfo projectTypeProperty = projectInSolutionType.GetProperty(
+                "ProjectType",
+                BindingFlags.NonPublic | BindingFlags.Instance);
             var projects = new List<ProjectInSolution>();
-            foreach (var proj in (object[])_projectsProperty.GetValue(solutionParser, index: null))
+            foreach (var proj in (object[])projectsProperty.GetValue(solutionParser, index: null))
             {
-                projects.Add(new ProjectInSolution(proj));
+                string projectType = projectTypeProperty.GetValue(proj, index: null).ToString();
+                var isSolutionFolder = projectType.Equals("SolutionFolder", StringComparison.OrdinalIgnoreCase);
+                var relativePath = (string)relativePathProperty.GetValue(proj, index: null);
+                projects.Add(new ProjectInSolution(relativePath, isSolutionFolder));
             }
             this.Projects = projects;
         }
 
-        private static Type GetSolutionParserType()
+        // Load the solution file using the public class SolutionFile in msbuild 14
+        private void LoadSolutionWithMsbuild14(Assembly msbuildAssembly, string solutionFileName)
         {
-            var assembly = typeof(Microsoft.Build.Construction.ProjectElement).Assembly;
-            var solutionParserType = assembly.GetType("Microsoft.Build.Construction.SolutionParser");
+            var solutionFileType = msbuildAssembly.GetType("Microsoft.Build.Construction.SolutionFile");
+            var parseMethod = solutionFileType.GetMethod("Parse", BindingFlags.Static | BindingFlags.Public);
+            dynamic solutionFile = parseMethod.Invoke(null, new object[] { solutionFileName });
+
+            // load projects
+            var projects = new List<ProjectInSolution>();
+            foreach (dynamic project in solutionFile.ProjectsInOrder)
+            {
+                string projectType = project.ProjectType.ToString();
+                var isSolutionFolder = projectType.Equals("SolutionFolder", StringComparison.OrdinalIgnoreCase);
+                string relativePath = project.RelativePath;
+                projects.Add(new ProjectInSolution(relativePath, isSolutionFolder));
+            }
+            this.Projects = projects;
+        }
+
+        private static Type GetSolutionParserType(Assembly msbuildAssembly)
+        {
+            var solutionParserType = msbuildAssembly.GetType("Microsoft.Build.Construction.SolutionParser");
 
             if (solutionParserType == null)
             {
@@ -56,35 +125,5 @@ namespace NuGet.Common
 
             return solutionParserType;
         }
-
-        private static PropertyInfo GetSolutionReaderProperty()
-        {
-            if (_solutionParserType != null)
-            {
-                return _solutionParserType.GetProperty("SolutionReader", BindingFlags.NonPublic | BindingFlags.Instance);
-            }
-
-            return null;
-        }
-
-        private static MethodInfo GetParseSolutionMethod()
-        {
-            if (_solutionParserType != null)
-            {
-                return _solutionParserType.GetMethod("ParseSolution", BindingFlags.NonPublic | BindingFlags.Instance);
-            }
-
-            return null;
-        }
-
-        private static PropertyInfo GetProjectsProperty()
-        {
-            if (_solutionParserType != null)
-            {
-                return _solutionParserType.GetProperty("Projects", BindingFlags.NonPublic | BindingFlags.Instance);
-            }
-
-            return null;
-        }
-    }    
+    }
 }

--- a/src/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -322,7 +322,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the version of MSBuild to be used with thise command. E.g. &quot;14&quot;. If not specified, nuget will use the msbuild found in PATH. If msbuild is not in PATH, then MSBuild version 4.0 will be used..
+        ///   Looks up a localized string similar to Specifies the version of MSBuild to be used with this command. For example, &quot;14&quot; for MSBuild version 14.0. If not specified, the MSBuild in PATH, or MSBuild version 4.0 if PATH does not contain MSBbuild, will be used..
         /// </summary>
         internal static string CommandMSBuildVersion {
             get {

--- a/src/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -322,6 +322,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specifies the version of MSBuild to be used with thise command. E.g. &quot;14&quot;. If not specified, nuget will use the msbuild found in PATH. If msbuild is not in PATH, then MSBuild version 4.0 will be used..
+        /// </summary>
+        internal static string CommandMSBuildVersion {
+            get {
+                return ResourceManager.GetString("CommandMSBuildVersion", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Disable using the machine cache as the first package source..
         /// </summary>
         internal static string CommandNoCache {
@@ -9671,15 +9680,6 @@ namespace NuGet.CommandLine {
         internal static string RestoreCommandDisableParallelProcessing_trk {
             get {
                 return ResourceManager.GetString("RestoreCommandDisableParallelProcessing_trk", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Path to MSBuild, defaults to &apos;%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe..
-        /// </summary>
-        internal static string RestoreCommandMsBuildPath {
-            get {
-                return ResourceManager.GetString("RestoreCommandMsBuildPath", resourceCulture);
             }
         }
         

--- a/src/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.CommandLine/NuGetCommand.resx
@@ -5239,7 +5239,7 @@ nuget update -Self</value>
   <data name="CommandFallbackSourceDescription" xml:space="preserve">
     <value>A list of packages sources to use as fallbacks for this command.</value>
   </data>
-  <data name="RestoreCommandMsBuildPath" xml:space="preserve">
-    <value>Path to MSBuild, defaults to '%ProgramFiles%\MSBuild\14.0\Bin\MSBuild.exe.</value>
+  <data name="CommandMSBuildVersion" xml:space="preserve">
+    <value>Specifies the version of MSBuild to be used with thise command. E.g. "14". If not specified, nuget will use the msbuild found in PATH. If msbuild is not in PATH, then MSBuild version 4.0 will be used.</value>
   </data>
 </root>

--- a/src/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.CommandLine/NuGetCommand.resx
@@ -5240,6 +5240,6 @@ nuget update -Self</value>
     <value>A list of packages sources to use as fallbacks for this command.</value>
   </data>
   <data name="CommandMSBuildVersion" xml:space="preserve">
-    <value>Specifies the version of MSBuild to be used with thise command. E.g. "14". If not specified, nuget will use the msbuild found in PATH. If msbuild is not in PATH, then MSBuild version 4.0 will be used.</value>
+    <value>Specifies the version of MSBuild to be used with this command. For example, "14" for MSBuild version 14.0. If not specified, the MSBuild in PATH, or MSBuild version 4.0 if PATH does not contain MSBbuild, will be used.</value>
   </data>
 </root>

--- a/src/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2329,6 +2329,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cannot find the specified version of msbuild: {1}.
+        /// </summary>
+        public static string Error_CannotFindMsbuild {
+            get {
+                return ResourceManager.GetString("Error_CannotFindMsbuild", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot get the GetAllProjectFileNamesMethod from type  Mono.XBuild.CommandLine.SolutionParser..
         /// </summary>
         public static string Error_CannotGetGetAllProjectFileNamesMethod {
@@ -3378,6 +3387,15 @@ namespace NuGet.CommandLine {
         public static string Error_SourceProviderIsNull_trk {
             get {
                 return ResourceManager.GetString("Error_SourceProviderIsNull_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to This version of msbuild is not supported: {0}.
+        /// </summary>
+        public static string Error_UnsupportedMsbuild {
+            get {
+                return ResourceManager.GetString("Error_UnsupportedMsbuild", resourceCulture);
             }
         }
         

--- a/src/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2329,7 +2329,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Cannot find the specified version of msbuild: {1}.
+        ///   Looks up a localized string similar to Cannot find the specified version of msbuild: &apos;{0}&apos;.
         /// </summary>
         public static string Error_CannotFindMsbuild {
             get {
@@ -2739,6 +2739,15 @@ namespace NuGet.CommandLine {
         public static string Error_CannotPromptForInput_trk {
             get {
                 return ResourceManager.GetString("Error_CannotPromptForInput_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Invalid MSBuild version specified: &apos;{0}&apos;.
+        /// </summary>
+        public static string Error_InvalidMsbuildVersion {
+            get {
+                return ResourceManager.GetString("Error_InvalidMsbuildVersion", resourceCulture);
             }
         }
         

--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -6047,6 +6047,9 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
     <value>This version of msbuild is not supported: {0}</value>
   </data>
   <data name="Error_CannotFindMsbuild" xml:space="preserve">
-    <value>Cannot find the specified version of msbuild: {1}</value>
+    <value>Cannot find the specified version of msbuild: '{0}'</value>
+  </data>
+  <data name="Error_InvalidMsbuildVersion" xml:space="preserve">
+    <value>Invalid MSBuild version specified: '{0}'</value>
   </data>
 </root>

--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -6043,4 +6043,10 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="Error_SolutionFileParseError" xml:space="preserve">
     <value>Error parsing solution file at {0}: {1}</value>
   </data>
+  <data name="Error_UnsupportedMsbuild" xml:space="preserve">
+    <value>This version of msbuild is not supported: {0}</value>
+  </data>
+  <data name="Error_CannotFindMsbuild" xml:space="preserve">
+    <value>Cannot find the specified version of msbuild: {1}</value>
+  </data>
 </root>

--- a/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -142,6 +142,182 @@ EndProject");
             }
         }
 
+        [Theory]
+        [InlineData("packages.config")]
+        [InlineData("packages.proj2.config")]
+        public void RestoreCommand_FromSolutionFileWithMsbuild12(string configFileName)
+        {
+            // Arrange
+            var tempPath = Path.GetTempPath();
+            var workingPath = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
+            var proj1Directory = Path.Combine(workingPath, "proj1");
+            var proj2Directory = Path.Combine(workingPath, "proj2");
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var nugetexe = Util.GetNuGetExePath();
+
+            try
+            {
+                Util.CreateDirectory(workingPath);
+                Util.CreateDirectory(repositoryPath);
+                Util.CreateDirectory(proj1Directory);
+                Util.CreateDirectory(proj2Directory);
+
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+
+                Util.CreateFile(workingPath, "a.sln",
+                    @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1\proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj2"", ""proj2\proj2.csproj"", ""{42641DAE-D6C4-49D4-92EA-749D2573554A}""
+EndProject");
+
+                Util.CreateFile(proj1Directory, "proj1.csproj",
+                    @"<Project ToolsVersion='4.0' DefaultTargets='Build' 
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include='packages.config' />
+  </ItemGroup>
+</Project>");
+                Util.CreateFile(proj1Directory, "packages.config",
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+</packages>");
+
+                Util.CreateFile(proj2Directory, "proj2.csproj",
+                    @"<Project ToolsVersion='4.0' DefaultTargets='Build' 
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include='packages.config' />
+  </ItemGroup>
+</Project>");
+                Util.CreateFile(proj2Directory, configFileName,
+@"<packages>
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+</packages>");
+
+                // Act 
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    "restore -Source " + repositoryPath + @" -msbuildversion 12",
+                    waitForExit: true);
+
+                // Assert
+                Assert.Equal(0, r.Item1);
+                var packageFileA = Path.Combine(workingPath, @"packages\packageA.1.1.0\packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, @"packages\packageB.2.2.0\packageB.2.2.0.nupkg");
+                Assert.True(File.Exists(packageFileA));
+                Assert.True(File.Exists(packageFileB));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(currentDirectory);
+                Util.DeleteDirectory(workingPath);
+            }
+        }
+
+        [Theory]
+        [InlineData("packages.config")]
+        [InlineData("packages.proj2.config")]
+        public void RestoreCommand_FromSolutionFileWithMsbuild14(string configFileName)
+        {
+            // Arrange
+            var tempPath = Path.GetTempPath();
+            var workingPath = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
+            var proj1Directory = Path.Combine(workingPath, "proj1");
+            var proj2Directory = Path.Combine(workingPath, "proj2");
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var nugetexe = Util.GetNuGetExePath();
+
+            try
+            {
+                Util.CreateDirectory(workingPath);
+                Util.CreateDirectory(repositoryPath);
+                Util.CreateDirectory(proj1Directory);
+                Util.CreateDirectory(proj2Directory);
+
+                Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
+                Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+
+                Util.CreateFile(workingPath, "a.sln",
+                    @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1\proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
+EndProject
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj2"", ""proj2\proj2.csproj"", ""{42641DAE-D6C4-49D4-92EA-749D2573554A}""
+EndProject");
+
+                Util.CreateFile(proj1Directory, "proj1.csproj",
+                    @"<Project ToolsVersion='4.0' DefaultTargets='Build' 
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include='packages.config' />
+  </ItemGroup>
+</Project>");
+                Util.CreateFile(proj1Directory, "packages.config",
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+</packages>");
+
+                Util.CreateFile(proj2Directory, "proj2.csproj",
+                    @"<Project ToolsVersion='4.0' DefaultTargets='Build' 
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include='packages.config' />
+  </ItemGroup>
+</Project>");
+                Util.CreateFile(proj2Directory, configFileName,
+@"<packages>
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+</packages>");
+
+                // Act 
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    "restore -Source " + repositoryPath + @" -MSBuildVersion 14.0",
+                    waitForExit: true);
+
+                // Assert
+                Assert.Equal(0, r.Item1);
+                var packageFileA = Path.Combine(workingPath, @"packages\packageA.1.1.0\packageA.1.1.0.nupkg");
+                var packageFileB = Path.Combine(workingPath, @"packages\packageB.2.2.0\packageB.2.2.0.nupkg");
+                Assert.True(File.Exists(packageFileA));
+                Assert.True(File.Exists(packageFileB));
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(currentDirectory);
+                Util.DeleteDirectory(workingPath);
+            }
+        }
+
         // Tests that if the project file cannot be loaded, i.e. InvalidProjectFileException is thrown,
         // Then packages listed in packages.config file will be restored.
         [Fact]


### PR DESCRIPTION
The problem is nuget always uses MSBUILD v4.0 to parse solution files. This will fail with new types of solutions/projects created by VS 2013 & VS 2014.

The fix is to let the user specify the msbuild to be used.
