### PR TITLE
Fix NuGet/Home#1107 and NuGet/Home#1048.

### DIFF
--- a/src/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.CommandLine/Commands/PackCommand.cs
@@ -102,12 +102,20 @@ namespace NuGet.CommandLine
         [ImportMany]
         public IEnumerable<IPackageRule> Rules { get; set; }
 
+        [Option(typeof(NuGetCommand), "CommandMSBuildVersion")]
+        public string MSBuildVersion { get; set; }
+
         // TODO: Temporarily hide the real ConfigFile parameter from the help text.
         // When we fix #3230, we should remove this property.
         public new string ConfigFile { get; set; }
 
+        // The directory that contains msbuild
+        private string _msbuildDirectory;
+
         public override void ExecuteCommand()
         {
+            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion);
+
             if (Verbose)
             {
                 Console.WriteWarning(LocalizedResourceManager.GetString("Option_VerboseDeprecated"));
@@ -361,7 +369,7 @@ namespace NuGet.CommandLine
 
         private IPackage BuildFromProjectFile(string path)
         {
-            var factory = new ProjectFactory(path, Properties)
+            var factory = new ProjectFactory(_msbuildDirectory, path, Properties)
             {
                 IsTool = Tool,
                 Logger = Console,

--- a/src/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -8326,6 +8326,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The directory of MSBuild. E.g. &quot;C:\Program Files (x86)\MSBuild\14.0\Bin&quot;. When the path is not specified, MSBuild v4.0 is used..
+        /// </summary>
+        internal static string PackCommandMsBuildPath {
+            get {
+                return ResourceManager.GetString("PackCommandMsBuildPath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to nuget pack
         ///
         ///nuget pack foo.nuspec

--- a/src/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.CommandLine/NuGetCommand.resx
@@ -5242,4 +5242,7 @@ nuget update -Self</value>
   <data name="CommandMSBuildVersion" xml:space="preserve">
     <value>Specifies the version of MSBuild to be used with this command. For example, "14" for MSBuild version 14.0. If not specified, the MSBuild in PATH, or MSBuild version 4.0 if PATH does not contain MSBbuild, will be used.</value>
   </data>
+  <data name="PackCommandMsBuildPath" xml:space="preserve">
+    <value>The directory of MSBuild. E.g. "C:\Program Files (x86)\MSBuild\14.0\Bin". When the path is not specified, MSBuild v4.0 is used.</value>
+  </data>
 </root>

--- a/test/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -38,7 +38,8 @@ namespace NuGet.CommandLine
                 Authors = "Outercurve Foundation",
             };
             var projectMock = new Mock<Project>();
-            var factory = new ProjectFactory(projectMock.Object);
+            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsbuildDirectory("4.0");
+            var factory = new ProjectFactory(msbuildDirectory, projectMock.Object);
 
             // act
             var author = factory.InitializeProperties(metadata);


### PR DESCRIPTION
The fix is to add new option -MSBuildVersion to the pack command so that the user
can specify the version of MSBuild to use instead of always using MSBuild v4.0. This is similar to fix of NuGet/Home#213

The changes are just to use dynamic/reflection instead of explicitly using the MSBuild 4.0 classes. They are basically direct translation of existing code, with additional changes for dynamic to work:
- LINQ can't be used with dynamic. So we have to use explicit iteration.
- Dynamic resolution does not work in some places. Reflection is used in such places.

@emgarten @deepakaravindr @yishaigalatzer @zhili1208 
