### PR TITLE
Fix NuGet/Home#1063: NuGet.exe update VS2013 solution and looking for wrong path of .target file.

### DIFF
--- a/src/NuGet.CommandLine/Commands/ProjectFactory.cs
+++ b/src/NuGet.CommandLine/Commands/ProjectFactory.cs
@@ -14,16 +14,10 @@ using NuGet.Configuration;
 namespace NuGet.CommandLine
 {
     [SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
-    public class ProjectFactory : IPropertyProvider
+    public class ProjectFactory : MSBuildUser, IPropertyProvider
     {
-        // The type of class Microsoft.Build.Evaluation.Project
-        private Type _projectType;
-
         // Its type is Microsoft.Build.Evaluation.Project
         private dynamic _project;
-
-        // The type of class Microsoft.Build.Evaluation.ProjectCollection
-        private Type _projectCollectionType;
 
         private Logging.ILogger _logger;
         private Configuration.ISettings _settings;
@@ -55,12 +49,6 @@ namespace NuGet.CommandLine
 
         [Import]
         public Configuration.IMachineWideSettings MachineWideSettings { get; set; }
-
-        // the Microsoft.Build.dll assembly
-        private Assembly _msbuildAssembly;
-
-        // the Microsoft.Build.Framework.dll assembly
-        private Assembly _frameworkAssembly;
 
         public ProjectFactory(string msbuildDirectory, string path, IDictionary<string, string> projectProperties)
         {
@@ -105,30 +93,6 @@ namespace NuGet.CommandLine
             {
                 TargetFramework = new FrameworkName(targetFrameworkMoniker);
             }
-        }
-
-        // msbuildDirectory is the directory containing the msbuild to be used. E.g. C:\Program Files (x86)\MSBuild\14.0\Bin
-        private void LoadAssemblies(string msbuildDirectory)
-        {
-            if (String.IsNullOrEmpty(msbuildDirectory))
-            {
-                throw new ArgumentNullException(nameof(msbuildDirectory));
-            }
-
-            _msbuildAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.dll"));
-            _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
-
-            LoadTypes();
-        }
-
-        private void LoadTypes()
-        {
-            _projectType = _msbuildAssembly.GetType(
-                "Microsoft.Build.Evaluation.Project",
-                throwOnError: true);
-            _projectCollectionType = _msbuildAssembly.GetType(
-                "Microsoft.Build.Evaluation.ProjectCollection",
-                throwOnError: true);
         }
 
         private Configuration.ISettings DefaultSettings

--- a/src/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -5,7 +5,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading.Tasks;
-using Microsoft.Build.Evaluation;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -17,14 +16,54 @@ namespace NuGet.Common
         private const string TargetName = "EnsureNuGetPackageBuildImports";
         private readonly string _projectDirectory;
 
-        public MSBuildProjectSystem(string projectFullPath, INuGetProjectContext projectContext)
+        // the Microsoft.Build.dll assembly
+        private Assembly _msbuildAssembly;
+
+        // the Microsoft.Build.Framework.dll assembly
+        private Assembly _frameworkAssembly;
+
+        // The type of class Microsoft.Build.Evaluation.Project
+        private Type _projectType;
+
+        // The type of class Microsoft.Build.Evaluation.ProjectCollection
+        private Type _projectCollectionType;
+
+        public MSBuildProjectSystem(
+            string msbuildDirectory, 
+            string projectFullPath, 
+            INuGetProjectContext projectContext)
         {
+            LoadAssemblies(msbuildDirectory);
+
             _projectDirectory = Path.GetDirectoryName(projectFullPath);
             ProjectFullPath = _projectDirectory;
             Project = GetProject(projectFullPath);
             ProjectName = Path.GetFileName(projectFullPath);
             ProjectUniqueName = projectFullPath;
             NuGetProjectContext = projectContext;
+        }
+
+        // msbuildDirectory is the directory containing the msbuild to be used. E.g. C:\Program Files (x86)\MSBuild\14.0\Bin
+        private void LoadAssemblies(string msbuildDirectory)
+        {
+            if (String.IsNullOrEmpty(msbuildDirectory))
+            {
+                throw new ArgumentNullException(nameof(msbuildDirectory));
+            }
+
+            _msbuildAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.dll"));
+            _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
+            LoadTypes();
+        }
+
+        private void LoadTypes()
+        {
+            _projectType = _msbuildAssembly.GetType(
+                "Microsoft.Build.Evaluation.Project",
+                throwOnError: true);
+            _projectCollectionType = _msbuildAssembly.GetType(
+                "Microsoft.Build.Evaluation.ProjectCollection",
+                throwOnError: true);
         }
 
         public INuGetProjectContext NuGetProjectContext { get; private set; }
@@ -51,7 +90,7 @@ namespace NuGet.Common
             }
         }
 
-        private Project Project { get; }
+        private dynamic Project { get; }
 
         public void AddBindingRedirects()
         {
@@ -81,9 +120,25 @@ namespace NuGet.Common
             }
 
             var targetRelativePath = PathUtility.GetRelativePath(PathUtility.EnsureTrailingSlash(_projectDirectory), targetFullPath);
+            var imports = Project.Xml.Imports;
+            bool notImported = true;
+            if (imports != null)
+            {
+                foreach (dynamic import in imports)
+                {
+                    if (targetRelativePath.Equals(import.Project, StringComparison.OrdinalIgnoreCase))
+                    {
+                        notImported = false;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                notImported = true;
+            }
 
-            if (Project.Xml.Imports == null ||
-                Project.Xml.Imports.All(import => !targetRelativePath.Equals(import.Project, StringComparison.OrdinalIgnoreCase)))
+            if (notImported)
             {
                 var pie = Project.Xml.AddImport(targetRelativePath);
                 pie.Condition = "Exists('" + targetRelativePath + "')";
@@ -140,9 +195,22 @@ namespace NuGet.Common
         {
             // some ItemTypes which starts with _ are added by various MSBuild tasks for their own purposes
             // and they do not represent content files of the projects. Therefore, we exclude them when checking for file existence.
-            return Project.Items.Any(
-                i => i.EvaluatedInclude.Equals(path, StringComparison.OrdinalIgnoreCase) &&
-                     (String.IsNullOrEmpty(i.ItemType) || i.ItemType[0] != '_'));
+            foreach (dynamic item in Project.Items)
+            {
+                // even though the type of Project.Items is ICollection<ProjectItem>, when dynamic is used
+                // the type of item is Dictionary.KeyValuePair, instead of ProjectItem. So another foreach
+                // is needed to iterate through all project items.
+                foreach (dynamic i in item.Value)
+                {
+                    if (i.EvaluatedInclude.Equals(path, StringComparison.OrdinalIgnoreCase) &&
+                         (String.IsNullOrEmpty(i.ItemType) || i.ItemType[0] != '_'))
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
         }
 
         public IEnumerable<string> GetDirectories(string path)
@@ -159,13 +227,14 @@ namespace NuGet.Common
 
         public IEnumerable<string> GetFullPaths(string fileName)
         {
-            return Project.Items.Where(
-                projectItem =>
+            foreach (dynamic projectItem in Project.Items)
+            {
+                var itemFileName = Path.GetFileName(projectItem.EvaluatedInclude);
+                if (string.Equals(fileName, itemFileName, StringComparison.OrdinalIgnoreCase))
                 {
-                    var itemFileName = Path.GetFileName(projectItem.EvaluatedInclude);
-                    return string.Equals(fileName, itemFileName, StringComparison.OrdinalIgnoreCase);
-                })
-                .Select(projectItem => Path.Combine(_projectDirectory, projectItem.EvaluatedInclude));
+                    yield return Path.Combine(_projectDirectory, projectItem.EvaluatedInclude);
+                }
+            }
         }
 
         public dynamic GetPropertyValue(string propertyName)
@@ -199,8 +268,15 @@ namespace NuGet.Common
             if (Project.Xml.Imports != null)
             {
                 // search for this import statement and remove it
-                var importElement = Project.Xml.Imports.FirstOrDefault(
-                    import => targetRelativePath.Equals(import.Project, StringComparison.OrdinalIgnoreCase));
+                dynamic importElement = null;
+                foreach (dynamic import in Project.Xml.Imports)
+                {
+                    if (targetRelativePath.Equals(import.Project, StringComparison.OrdinalIgnoreCase))
+                    {
+                        importElement = import;
+                        break;
+                    }
+                }
 
                 if (importElement != null)
                 {
@@ -215,7 +291,7 @@ namespace NuGet.Common
 
         public void RemoveReference(string name)
         {
-            ProjectItem assemblyReference = GetReference(name);
+            dynamic assemblyReference = GetReference(name);
             if (assemblyReference != null)
             {
                 Project.RemoveItem(assemblyReference);
@@ -232,12 +308,18 @@ namespace NuGet.Common
             NuGetProjectContext = nuGetProjectContext;
         }
 
-        private IEnumerable<ProjectItem> GetItems(string itemType, string name)
+        private IEnumerable<dynamic> GetItems(string itemType, string name)
         {
-            return Project.GetItems(itemType).Where(i => i.EvaluatedInclude.StartsWith(name, StringComparison.OrdinalIgnoreCase));
+            foreach (dynamic i in Project.GetItems(itemType))
+            {
+                if (i.EvaluatedInclude.StartsWith(name, StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return i;
+                }
+            }
         }
 
-        private ProjectItem GetReference(string name)
+        private dynamic GetReference(string name)
         {
             name = Path.GetFileNameWithoutExtension(name);
             return GetItems("Reference", name)
@@ -249,8 +331,15 @@ namespace NuGet.Common
         private void AddEnsureImportedTarget(string targetsPath)
         {
             // get the target
-            var targetElement = Project.Xml.Targets.FirstOrDefault(
-                target => target.Name.Equals(TargetName, StringComparison.OrdinalIgnoreCase));
+            dynamic targetElement = null;
+            foreach (dynamic target in Project.Xml.Targets)
+            {
+                if (target.Name.Equals(TargetName, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetElement = target;
+                    break;
+                }
+            }
 
             // if the target does not exist, create the target
             if (targetElement == null)
@@ -278,16 +367,30 @@ namespace NuGet.Common
 
         private void RemoveEnsureImportedTarget(string targetsPath)
         {
-            var targetElement = Project.Xml.Targets.FirstOrDefault(
-                target => string.Equals(target.Name, targetsPath, StringComparison.OrdinalIgnoreCase));
+            dynamic targetElement = null;
+            foreach (dynamic target in Project.Xml.Targets)
+            {
+                if (string.Equals(target.Name, targetsPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    targetElement = target;
+                    break;
+                }
+            }
             if (targetElement == null)
             {
                 return;
             }
 
             string errorCondition = "!Exists('" + targetsPath + "')";
-            var taskElement = targetElement.Tasks.FirstOrDefault(
-                task => string.Equals(task.Condition, errorCondition, StringComparison.OrdinalIgnoreCase));
+            dynamic taskElement = null;
+            foreach (dynamic task in targetElement.Tasks)
+            {
+                if (string.Equals(task.Condition, errorCondition, StringComparison.OrdinalIgnoreCase))
+                {
+                    taskElement = task;
+                    break;
+                }
+            }
             if (taskElement == null)
             {
                 return;
@@ -300,9 +403,22 @@ namespace NuGet.Common
             }
         }
 
-        private static Project GetProject(string projectFile)
+        private dynamic GetProject(string projectFile)
         {
-            return ProjectCollection.GlobalProjectCollection.GetLoadedProjects(projectFile).FirstOrDefault() ?? new Project(projectFile);
+            dynamic globalProjectCollection = _projectCollectionType
+                .GetProperty("GlobalProjectCollection")
+                .GetMethod
+                .Invoke(null, new object[] { });
+            var loadedProjects = globalProjectCollection.GetLoadedProjects(projectFile);
+            if (loadedProjects.Count > 0)
+            {
+                return loadedProjects[0];
+            }
+
+            var project = Activator.CreateInstance(
+                _projectType,
+                new object[] { projectFile });
+            return project;
         }
     }
 }

--- a/src/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -11,22 +11,10 @@ using NuGet.ProjectManagement;
 
 namespace NuGet.Common
 {
-    public class MSBuildProjectSystem : IMSBuildNuGetProjectSystem
+    public class MSBuildProjectSystem : MSBuildUser, IMSBuildNuGetProjectSystem
     {
         private const string TargetName = "EnsureNuGetPackageBuildImports";
         private readonly string _projectDirectory;
-
-        // the Microsoft.Build.dll assembly
-        private Assembly _msbuildAssembly;
-
-        // the Microsoft.Build.Framework.dll assembly
-        private Assembly _frameworkAssembly;
-
-        // The type of class Microsoft.Build.Evaluation.Project
-        private Type _projectType;
-
-        // The type of class Microsoft.Build.Evaluation.ProjectCollection
-        private Type _projectCollectionType;
 
         public MSBuildProjectSystem(
             string msbuildDirectory, 
@@ -41,29 +29,6 @@ namespace NuGet.Common
             ProjectName = Path.GetFileName(projectFullPath);
             ProjectUniqueName = projectFullPath;
             NuGetProjectContext = projectContext;
-        }
-
-        // msbuildDirectory is the directory containing the msbuild to be used. E.g. C:\Program Files (x86)\MSBuild\14.0\Bin
-        private void LoadAssemblies(string msbuildDirectory)
-        {
-            if (String.IsNullOrEmpty(msbuildDirectory))
-            {
-                throw new ArgumentNullException(nameof(msbuildDirectory));
-            }
-
-            _msbuildAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.dll"));
-            _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
-            LoadTypes();
-        }
-
-        private void LoadTypes()
-        {
-            _projectType = _msbuildAssembly.GetType(
-                "Microsoft.Build.Evaluation.Project",
-                throwOnError: true);
-            _projectCollectionType = _msbuildAssembly.GetType(
-                "Microsoft.Build.Evaluation.ProjectCollection",
-                throwOnError: true);
         }
 
         public INuGetProjectContext NuGetProjectContext { get; private set; }

--- a/src/NuGet.CommandLine/Common/MSBuildUser.cs
+++ b/src/NuGet.CommandLine/Common/MSBuildUser.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Reflection;
+
+namespace NuGet.Common
+{
+    public abstract class MSBuildUser
+    {
+        // the Microsoft.Build.dll assembly
+        protected Assembly _msbuildAssembly;
+
+        // the Microsoft.Build.Framework.dll assembly
+        protected Assembly _frameworkAssembly;
+
+        // The type of class Microsoft.Build.Evaluation.Project
+        protected Type _projectType;
+
+        // The type of class Microsoft.Build.Evaluation.ProjectCollection
+        protected Type _projectCollectionType;
+
+        // msbuildDirectory is the directory containing the msbuild to be used. E.g. C:\Program Files (x86)\MSBuild\14.0\Bin
+        public void LoadAssemblies(string msbuildDirectory)
+        {
+            if (String.IsNullOrEmpty(msbuildDirectory))
+            {
+                throw new ArgumentNullException(nameof(msbuildDirectory));
+            }
+
+            _msbuildAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.dll"));
+            _frameworkAssembly = Assembly.LoadFile(Path.Combine(msbuildDirectory, "Microsoft.Build.Framework.dll"));
+
+            LoadTypes();
+        }
+
+        public void LoadTypes()
+        {
+            _projectType = _msbuildAssembly.GetType(
+                "Microsoft.Build.Evaluation.Project",
+                throwOnError: true);
+            _projectCollectionType = _msbuildAssembly.GetType(
+                "Microsoft.Build.Evaluation.ProjectCollection",
+                throwOnError: true);
+        }
+    }
+}

--- a/src/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -77,6 +77,7 @@
     <Compile Include="Common\IMSBuildProjectSystem.cs" />
     <Compile Include="Common\LocalizedResourceManager.cs" />
     <Compile Include="Common\MSBuildProjectSystem.cs" />
+    <Compile Include="Common\MSBuildUser.cs" />
     <Compile Include="Common\PackageExtractor.cs" />
     <Compile Include="Common\PackageSourceProviderExtensions.cs" />
     <Compile Include="Common\ProjectHelper.cs" />

--- a/src/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.CommandLine/Program.cs
@@ -115,10 +115,13 @@ namespace NuGet.CommandLine
                     // If the AggregateException contains more than one InnerException, it cannot be unwrapped. In which case, simply print out individual error messages
                     message = String.Join(Environment.NewLine, exception.InnerExceptions.Select(getErrorMessage).Distinct(StringComparer.CurrentCulture));
                 }
+                else if (unwrappedEx is System.Reflection.TargetInvocationException)
+                {
+                    message = getErrorMessage(unwrappedEx.InnerException);
+                }
                 else
                 {
-
-                    message = getErrorMessage(ExceptionUtility.Unwrap(exception));
+                    message = getErrorMessage(unwrappedEx);
                 }
                 console.WriteError(message);
                 return 1;


### PR DESCRIPTION
The fix is to add new option -MSBuildVersion to the update command so that the user
can specify the version of MSBuild to used instead of always using MSBuild v4.0.

@emgarten @yishaigalatzer @deepakaravindr @zhili1208 
