### PR TITLE
Retry for packages.config restore and integration tests

### DIFF
--- a/src/PackageManagement/Strings.Designer.cs
+++ b/src/PackageManagement/Strings.Designer.cs
@@ -133,6 +133,15 @@ namespace NuGet.PackageManagement {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Retrying package restore for &apos;{0}&apos;..
+        /// </summary>
+        internal static string Debug_RestoreRetry {
+            get {
+                return ResourceManager.GetString("Debug_RestoreRetry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cannot download packages from &apos;{0}&apos;..
         /// </summary>
         internal static string DownloadResourceNotFound {

--- a/src/PackageManagement/Strings.resx
+++ b/src/PackageManagement/Strings.resx
@@ -258,4 +258,7 @@
   <data name="UnsupportedPackageFeature" xml:space="preserve">
     <value>Package '{0}' uses features that are not supported by the current version of NuGet. To upgrade NuGet, see http://docs.nuget.org/consume/installing-nuget.</value>
   </data>
+  <data name="Debug_RestoreRetry" xml:space="preserve">
+    <value>Retrying package restore for '{0}'.</value>
+  </data>
 </root>

--- a/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -75,6 +75,7 @@
     <Compile Include="PackageCreator.cs" />
     <Compile Include="ProjectFactoryTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="RestoreRetryTests.cs" />
     <Compile Include="Util.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/test/NuGet.CommandLine.Test/RestoreRetryTests.cs
+++ b/test/NuGet.CommandLine.Test/RestoreRetryTests.cs
@@ -1,0 +1,638 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class RestoreRetryTests : IDisposable
+    {
+        // Restore a packages.config file from a failing v2 http source.
+        [Fact]
+        public void RestoreRetry_PackagesConfigRetryOnFailingV2Source()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var tempPath = Path.GetTempPath();
+            var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            _dirs.Add(workingDirectory);
+            _dirs.Add(packageDirectory);
+
+            // Arrange
+            Util.CreateDirectory(packageDirectory);
+            Util.CreateDirectory(workingDirectory);
+            var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+            var package = new ZipPackage(packageFileName);
+            MachineCache.Default.RemovePackage(package);
+
+            Util.CreateFile(
+                workingDirectory,
+                "packages.config",
+                @"<packages>
+                     <package id=""testPackage1"" version=""1.1.0"" />
+                  </packages>");
+
+            // Server setup
+            using (var server = new MockServer())
+            {
+                var hitsByUrl = new ConcurrentDictionary<string, int>();
+
+                server.Get.Add("/", r =>
+                {
+                    var path = r.Url.PathAndQuery;
+
+                    // track hits on the url
+                    var urlHits = hitsByUrl.AddOrUpdate(path, 1, (s, i) => i + 1);
+
+                    if (path == "/nuget/$metadata")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            MockServer.SetResponseContent(response, MockServerResource.NuGetV2APIMetadata);
+                        });
+                    }
+                    else if (path == "/package/testPackage1/1.1.0")
+                    {
+                        // Fail on the first two requests for this download
+                        if (urlHits < 3)
+                        {
+                            return new Action<HttpListenerResponse>(response =>
+                            {
+                                response.StatusCode = 503;
+                            });
+                        }
+
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/zip";
+                            using (var stream = package.GetStream())
+                            {
+                                var content = stream.ReadAllBytes();
+                                MockServer.SetResponseContent(response, content);
+                            }
+                        });
+                    }
+                    else if (path == "/nuget/Packages(Id='testPackage1',Version='1.1.0')")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/atom+xml;type=entry;charset=utf-8";
+                            var odata = server.ToOData(package);
+                            MockServer.SetResponseContent(response, odata);
+                        });
+                    }
+                    else if (path == "/nuget")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 200;
+                        });
+                    }
+
+                    throw new Exception("This test needs to be updated to support: " + path);
+                });
+
+                server.Start();
+
+                // Act
+                var args = string.Format(
+                    "restore packages.config -SolutionDirectory . -Source {0}nuget -NoCache",
+                        server.Uri);
+
+                var timer = new Stopwatch();
+                timer.Start();
+
+                var r1 = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    args,
+                    waitForExit: true);
+
+                timer.Stop();
+                server.Stop();
+
+                // Assert
+                Assert.True(Util.IsSuccess(r1), r1.Item2 + " " + r1.Item3);
+
+                Assert.True(
+                    File.Exists(
+                        Path.Combine(workingDirectory,
+                            "packages/testpackage1.1.1.0/testpackage1.1.1.0.nupkg")));
+            }
+        }
+
+        // Restore project.json from a failing v2 http source.
+        [Fact]
+        public void RestoreRetry_ProjectJsonRetryOnFailingV2Source()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var tempPath = Path.GetTempPath();
+            var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            _dirs.Add(workingDirectory);
+            _dirs.Add(packageDirectory);
+
+            // Arrange
+            Util.CreateDirectory(packageDirectory);
+            Util.CreateDirectory(workingDirectory);
+            var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+            var package = new ZipPackage(packageFileName);
+
+            Util.CreateFile(
+                workingDirectory,
+                "project.json",
+                @"{
+                    ""dependencies"": {
+                        ""testPackage1"": ""1.1.0""
+                    },
+                    ""frameworks"": {
+                                ""net45"": { }
+                                }
+                  }");
+
+            Util.CreateFile(
+                workingDirectory,
+                "nuget.config",
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <configuration>
+                          <config>
+                            <add key=""globalPackagesFolder"" value=""globalPackages"" />
+                          </config>
+                        </configuration>");
+
+            // Server setup
+            using (var server = new MockServer())
+            {
+                var hitsByUrl = new ConcurrentDictionary<string, int>();
+
+                server.Get.Add("/", r =>
+                {
+                    var path = r.Url.PathAndQuery;
+
+                    // track hits on the url
+                    var urlHits = hitsByUrl.AddOrUpdate(path, 1, (s, i) => i + 1);
+
+                    // Fail on the first 3 requests for every url
+                    if (urlHits < 4)
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 503;
+                        });
+                    }
+
+                    if (path == "/nuget/$metadata")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            MockServer.SetResponseContent(response, MockServerResource.NuGetV2APIMetadata);
+                        });
+                    }
+                    else if (path == "/package/testPackage1/1.1.0")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/zip";
+                            using (var stream = package.GetStream())
+                            {
+                                var content = stream.ReadAllBytes();
+                                MockServer.SetResponseContent(response, content);
+                            }
+                        });
+                    }
+                    else if (path == "/nuget/FindPackagesById()?id='testPackage1'")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/atom+xml;type=feed;charset=utf-8";
+                            string feed = server.ToODataFeed(new[] { package }, "FindPackagesById");
+                            MockServer.SetResponseContent(response, feed);
+                        });
+                    }
+                    else if (path == "/nuget")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 200;
+                        });
+                    }
+
+                    throw new Exception("This test needs to be updated to support: " + path);
+                });
+
+                server.Start();
+
+                // Act
+                var args = string.Format(
+                    "restore project.json -SolutionDirectory . -Source {0}nuget -NoCache",
+                        server.Uri);
+
+                var timer = new Stopwatch();
+                timer.Start();
+
+                var r1 = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    args,
+                    waitForExit: true);
+
+                timer.Stop();
+
+                server.Stop();
+
+                // Assert
+                Assert.True(Util.IsSuccess(r1), r1.Item2 + " " + r1.Item3);
+
+                Assert.True(
+                    File.Exists(
+                        Path.Combine(workingDirectory,
+                            "globalPackages/testpackage1/1.1.0/testpackage1.1.1.0.nupkg")));
+
+                Assert.True(
+                    File.Exists(
+                        Path.Combine(workingDirectory,
+                            "globalPackages/testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
+
+                Assert.True(File.Exists(Path.Combine(workingDirectory, "project.lock.json")));
+
+                // Everything should be hit 4 times
+                foreach (var url in hitsByUrl.Keys)
+                {
+                    Assert.True(hitsByUrl[url] == 4, url);
+                }
+            }
+        }
+
+        // Restore project.json from a failing v3 http source.
+        [Fact]
+        public void RestoreRetry_ProjectJsonRetryOnFailingV3Source()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var tempPath = Path.GetTempPath();
+            var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            _dirs.Add(workingDirectory);
+            _dirs.Add(packageDirectory);
+
+            // Arrange
+            Util.CreateDirectory(packageDirectory);
+            Util.CreateDirectory(workingDirectory);
+            var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+            var package = new ZipPackage(packageFileName);
+            MachineCache.Default.RemovePackage(package);
+
+            Util.CreateFile(
+                workingDirectory,
+                "project.json",
+                @"{
+                    ""dependencies"": {
+                        ""testPackage1"": ""1.1.0""
+                    },
+                    ""frameworks"": {
+                                ""net45"": { }
+                                }
+                  }");
+
+            Util.CreateFile(
+                workingDirectory,
+                "nuget.config",
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <configuration>
+                          <config>
+                            <add key=""globalPackagesFolder"" value=""globalPackages"" />
+                          </config>
+                        </configuration>");
+
+            // Server setup
+            var indexJson = Util.CreateIndexJson();
+
+            using (var server = new MockServer())
+            {
+                Util.AddFlatContainerResource(indexJson, server);
+                Util.AddRegistrationResource(indexJson, server);
+                var hitsByUrl = new ConcurrentDictionary<string, int>();
+
+                server.Get.Add("/", r =>
+                {
+                    var path = r.Url.AbsolutePath;
+
+                    // track hits on the url
+                    var urlHits = hitsByUrl.AddOrUpdate(path, 1, (s, i) => i + 1);
+
+                    // Fail on the first 3 requests for every url
+                    if (urlHits < 4)
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 503;
+                        });
+                    }
+
+                    if (path == "/index.json")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 200;
+                            response.ContentType = "text/javascript";
+                            MockServer.SetResponseContent(response, indexJson.ToString());
+                        });
+                    }
+                    else if (path == "/flat/testpackage1/1.1.0/testpackage1.1.1.0.nupkg")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/zip";
+                            using (var stream = package.GetStream())
+                            {
+                                var content = stream.ReadAllBytes();
+                                MockServer.SetResponseContent(response, content);
+                            }
+                        });
+                    }
+                    else if (path == "/flat/testpackage1/index.json")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "text/javascript";
+
+                            MockServer.SetResponseContent(response, @"{
+                              ""versions"": [
+                                ""0.1.0"",
+                                ""0.3.0"",
+                                ""0.4.0"",
+                                ""0.5.0"",
+                                ""1.0.0"",
+                                ""1.1.0"",
+                                ""1.2.0""
+                              ]
+                            }");
+                        });
+                    }
+
+                    throw new Exception("This test needs to be updated to support: " + path);
+                });
+
+                server.Start();
+
+                // The minimum time is the number of urls x 3 waits x 200ms
+                var minTime = TimeSpan.FromMilliseconds(hitsByUrl.Count * 3 * 200);
+
+                // Act
+                var args = string.Format(
+                    "restore project.json -SolutionDirectory . -Source {0}index.json -NoCache",
+                        server.Uri);
+
+                var timer = new Stopwatch();
+                timer.Start();
+
+                var r1 = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    args,
+                    waitForExit: true);
+
+                timer.Stop();
+
+                server.Stop();
+
+                // Assert
+                Assert.True(Util.IsSuccess(r1), r1.Item2 + " " + r1.Item3);
+
+                Assert.True(
+                    File.Exists(
+                        Path.Combine(workingDirectory,
+                            "globalPackages/testpackage1/1.1.0/testpackage1.1.1.0.nupkg")));
+
+                Assert.True(
+                    File.Exists(
+                        Path.Combine(workingDirectory,
+                            "globalPackages/testpackage1/1.1.0/testPackage1.1.1.0.nupkg.sha512")));
+
+                Assert.True(File.Exists(Path.Combine(workingDirectory, "project.lock.json")));
+
+                // Everything should be hit 4 times
+                foreach (var url in hitsByUrl.Keys)
+                {
+                    Assert.True(hitsByUrl[url] == 4, url);
+                }
+
+                Assert.True(timer.Elapsed > minTime);
+            }
+        }
+
+        // Restore packages.config from a failing v3 http source.
+        [Fact]
+        public void RestoreRetry_PackagesConfigRetryOnFailingV3Source()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var tempPath = Path.GetTempPath();
+            var workingDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            var packageDirectory = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            _dirs.Add(workingDirectory);
+            _dirs.Add(packageDirectory);
+
+            // Arrange
+            Util.CreateDirectory(packageDirectory);
+            Util.CreateDirectory(workingDirectory);
+            var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packageDirectory);
+            var package = new ZipPackage(packageFileName);
+            MachineCache.Default.RemovePackage(package);
+
+            Util.CreateFile(
+                workingDirectory,
+                "packages.config",
+                @"<packages>
+                    <package id=""testPackage1"" version=""1.1.0"" />
+                  </packages>");
+
+            Util.CreateFile(
+                workingDirectory,
+                "nuget.config",
+                    @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <configuration>
+                            <config>
+                            <add key=""globalPackagesFolder"" value=""globalPackages"" />
+                            </config>
+                        </configuration>");
+
+            // Server setup
+            var indexJson = Util.CreateIndexJson();
+
+            using (var server = new MockServer())
+            {
+                Util.AddFlatContainerResource(indexJson, server);
+                Util.AddRegistrationResource(indexJson, server);
+                var hitsByUrl = new ConcurrentDictionary<string, int>();
+
+                server.Get.Add("/", r =>
+                {
+                    var path = r.Url.AbsolutePath;
+
+                    // track hits on the url
+                    var urlHits = hitsByUrl.AddOrUpdate(path, 1, (s, i) => i + 1);
+
+                    // Fail on the first 3 requests for every url
+                    if (urlHits < 4)
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 503;
+                        });
+                    }
+
+                    if (path == "/index.json")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.StatusCode = 200;
+                            response.ContentType = "text/javascript";
+                            MockServer.SetResponseContent(response, indexJson.ToString());
+                        });
+                    }
+                    else if (path == "/packages/testPackage1.1.1.0.nupkg")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "application/zip";
+                            using (var stream = package.GetStream())
+                            {
+                                var content = stream.ReadAllBytes();
+                                MockServer.SetResponseContent(response, content);
+                            }
+                        });
+                    }
+                    else if (path == "/reg/testpackage1/index.json")
+                    {
+                        return new Action<HttpListenerResponse>(response =>
+                        {
+                            response.ContentType = "text/javascript";
+
+                            string json = null;
+
+                            json = @"{
+                    ""@id"": ""{0}/reg/testPackage1/index.json"",
+                    ""@type"": [
+                    ""catalog:CatalogRoot"",
+                    ""PackageRegistration"",
+                    ""catalog:Permalink""
+                    ],
+                    ""commitId"": ""6d2d2375-b263-49ee-9a46-fd6b2d77e592"",
+                    ""commitTimeStamp"": ""2015-06-22T22:30:00.1487642Z"",
+                    ""count"": 1,
+                    ""items"": [
+                    {
+                        ""@id"": ""{0}reg/testPackage1/index.json#page/0.0.0/9.0.0"",
+                        ""@type"": ""catalog:CatalogPage"",
+                        ""commitId"": ""6d2d2375-b263-49ee-9a46-fd6b2d77e592"",
+                        ""commitTimeStamp"": ""2015-06-22T22:30:00.1487642Z"",
+                        ""count"": 1,
+                        ""items"": [
+                        {
+                            ""@id"": ""{0}reg/testPackage1/1.1.0.json"",
+                            ""@type"": ""Package"",
+                            ""commitId"": ""1fa214b1-6a03-4b4e-a16e-4925f994057f"",
+                            ""commitTimeStamp"": ""2015-04-01T20:27:37.8431747Z"",
+                            ""catalogEntry"": {
+                            ""@id"": ""{0}catalog0/data/2015.02.01.06.24.15/testPackage1.1.1.0.json"",
+                            ""@type"": ""PackageDetails"",
+                            ""authors"": ""test master"",
+                            ""description"": ""test one"",
+                            ""iconUrl"": """",
+                            ""id"": ""testPackage1"",
+                            ""language"": ""en-US"",
+                            ""licenseUrl"": """",
+                            ""listed"": true,
+                            ""minClientVersion"": """",
+                            ""projectUrl"": """",
+                            ""published"": ""2012-01-01T22:12:57.713Z"",
+                            ""requireLicenseAcceptance"": false,
+                            ""summary"": ""stuffs"",
+                            ""tags"": [
+                                """"
+                            ],
+                            ""title"": """",
+                            ""version"": ""1.1.0""
+                            },
+                            ""packageContent"": ""{0}packages/testPackage1.1.1.0.nupkg"",
+                            ""registration"": ""{0}reg/testPackage1/index.json""
+                        }],
+                ""parent"": ""{0}reg/testPackage1/index.json"",
+                        ""lower"": ""0.0.0"",
+                        ""upper"": ""9.0.0""
+                    }
+                    ]}".Replace("{0}", server.Uri);
+
+                            var jObject = JObject.Parse(json);
+
+                            MockServer.SetResponseContent(response, jObject.ToString());
+                        });
+                    }
+
+                    throw new Exception("This test needs to be updated to support: " + path);
+                });
+
+                server.Start();
+
+                // The minimum time is the number of urls x 3 waits x 200ms
+                var minTime = TimeSpan.FromMilliseconds(hitsByUrl.Count * 3 * 200);
+
+                // Act
+                var args = string.Format(
+                    "restore packages.config -SolutionDirectory . -Source {0}index.json -NoCache",
+                        server.Uri);
+
+                var timer = new Stopwatch();
+                timer.Start();
+
+                var r1 = CommandRunner.Run(
+                    nugetexe,
+                    workingDirectory,
+                    args,
+                    waitForExit: true);
+
+                timer.Stop();
+
+                server.Stop();
+
+                // Assert
+                Assert.True(Util.IsSuccess(r1), r1.Item2 + " " + r1.Item3);
+
+                Assert.True(
+                    File.Exists(
+                        Path.Combine(workingDirectory,
+                            "packages/testpackage1.1.1.0/testpackage1.1.1.0.nupkg")));
+
+                // Everything should be hit 4 times
+                foreach (var url in hitsByUrl.Keys)
+                {
+                    Assert.True(hitsByUrl[url] == 4, url);
+                }
+
+                Assert.True(timer.Elapsed > minTime);
+            }
+        }
+
+        /// <summary>
+        /// Store all directories used by the unit tests and clean them up at the end during Dispose()
+        /// </summary>
+        private ConcurrentBag<string> _dirs = new ConcurrentBag<string>();
+
+        public void Dispose()
+        {
+            foreach (var dir in _dirs)
+            {
+                try
+                {
+                    Util.DeleteDirectory(dir);
+                }
+                catch
+                {
+
+                }
+            }
+        }
+    }
+}

--- a/test/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.CommandLine.Test/Util.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Net;
 using System.Text;
 using Moq;
+using Newtonsoft.Json.Linq;
 
 namespace NuGet.CommandLine.Test
 {
@@ -205,6 +206,42 @@ namespace NuGet.CommandLine.Test
             var targetDir = ConfigurationManager.AppSettings["TargetDir"] ?? Directory.GetCurrentDirectory();
             var nugetexe = Path.Combine(targetDir, "nuget.exe");
             return nugetexe;
+        }
+
+        public static bool IsSuccess(Tuple<int, string, string> result)
+        {
+            return result.Item1 == 0;
+        }
+
+        public static JObject CreateIndexJson()
+        {
+            return JObject.Parse(@"{
+                  ""version"": ""3.2.0"",
+                  ""resources"": [],
+                ""@context"": {
+                ""@vocab"": ""http://schema.nuget.org/services#"",
+                ""comment"": ""http://www.w3.org/2000/01/rdf-schema#comment""
+                    }}");
+        }
+
+        public static void AddFlatContainerResource(JObject index, MockServer server)
+        {
+            var resource = new JObject();
+            resource.Add("@id", string.Format("{0}flat", server.Uri));
+            resource.Add("@type", "PackageBaseAddress/3.0.0");
+
+            var array = index["resources"] as JArray;
+            array.Add(resource);
+        }
+
+        public static void AddRegistrationResource(JObject index, MockServer server)
+        {
+            var resource = new JObject();
+            resource.Add("@id", string.Format("{0}reg", server.Uri));
+            resource.Add("@type", "RegistrationsBaseUrl/3.0.0-beta");
+
+            var array = index["resources"] as JArray;
+            array.Add(resource);
         }
     }
 }


### PR DESCRIPTION
This change adds a retry around package restore for packages.config. For 503 scenarios the v2 calls in NuGet.Core were not retrying, to avoid adding more retry logic in nuget.core or all v2 resources I've put this in one place around the actual restore. This now matches how the project.json restore retries for downloading and extracting the package.

Mock server tests have been added to cover:
- packages.config + V2
- packages.config + V3
- project.json + V2
- project.json + V3

//cc @deepakaravindr @MeniZalzman @feiling @yishaigalatzer 
