### PR TITLE
fixed https://github.com/NuGet/Home/issues/1186

### DIFF
--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -48,7 +48,7 @@ namespace NuGet.CommandLine
         public override async Task ExecuteCommandAsync()
         {
             bool restoreResult = true;
-            
+
             _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion);
 
             if (!string.IsNullOrEmpty(PackagesDirectory))
@@ -97,14 +97,15 @@ namespace NuGet.CommandLine
                 if (v3RestoreTasks.Count > 0)
                 {
                     var results = await Task.WhenAll(v3RestoreTasks);
-                    foreach(var result in results)
+                    restoreResult &= results.All(r => r);
+                    foreach (var result in results)
                     {
                         restoreResult &= result;
                     }
                 }
             }
 
-            if(!restoreResult)
+            if (!restoreResult)
             {
                 throw new CommandLineException();
             }

--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -47,6 +47,8 @@ namespace NuGet.CommandLine
 
         public override async Task ExecuteCommandAsync()
         {
+            bool restoreResult = true;
+            
             _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion);
 
             if (!string.IsNullOrEmpty(PackagesDirectory))
@@ -62,7 +64,8 @@ namespace NuGet.CommandLine
             var restoreInputs = DetermineRestoreInputs();
             if (restoreInputs.PackageReferenceFiles.Count > 0)
             {
-                await PerformNuGetV2RestoreAsync(restoreInputs);
+                var v2RestoreResult = await PerformNuGetV2RestoreAsync(restoreInputs);
+                restoreResult &= v2RestoreResult;
             }
 
             if (restoreInputs.V3RestoreFiles.Count > 0)
@@ -78,7 +81,7 @@ namespace NuGet.CommandLine
                                     restoreInputs,
                                     globalPackagesFolder);
 
-                var v3RestoreTasks = new List<Task>();
+                var v3RestoreTasks = new List<Task<bool>>();
                 foreach (var file in restoreInputs.V3RestoreFiles)
                 {
                     if (DisableParallelProcessing)
@@ -93,8 +96,17 @@ namespace NuGet.CommandLine
 
                 if (v3RestoreTasks.Count > 0)
                 {
-                    await Task.WhenAll(v3RestoreTasks);
+                    var results = await Task.WhenAll(v3RestoreTasks);
+                    foreach(var result in results)
+                    {
+                        restoreResult &= result;
+                    }
                 }
+            }
+
+            if(!restoreResult)
+            {
+                throw new CommandLineException();
             }
         }
 
@@ -136,7 +148,7 @@ namespace NuGet.CommandLine
             throw new CommandLineException(message);
         }
 
-        private async Task PerformNuGetV3RestoreAsync(string packagesDir, string projectPath)
+        private async Task<bool> PerformNuGetV3RestoreAsync(string packagesDir, string projectPath)
         {
             var projectFileName = Path.GetFileName(projectPath);
             PackageSpec project;
@@ -242,6 +254,8 @@ namespace NuGet.CommandLine
             var command = new Commands.RestoreCommand(Console, request);
             var result = await command.ExecuteAsync();
             result.Commit(Console);
+
+            return result.Success;
         }
 
         private void ReadSettings(PackageRestoreInputs packageRestoreInputs)
@@ -273,7 +287,7 @@ namespace NuGet.CommandLine
             }
         }
 
-        private async Task PerformNuGetV2RestoreAsync(PackageRestoreInputs packageRestoreInputs)
+        private async Task<bool> PerformNuGetV2RestoreAsync(PackageRestoreInputs packageRestoreInputs)
         {
             ReadSettings(packageRestoreInputs);
             var packagesFolderPath = GetPackagesFolder(packageRestoreInputs);
@@ -326,7 +340,7 @@ namespace NuGet.CommandLine
                     "packages.config");
 
                 Console.LogInformation(message);
-                return;
+                return true;
             }
 
             var packageRestoreData = missingPackageReferences.Select(reference =>
@@ -356,7 +370,7 @@ namespace NuGet.CommandLine
                         : PackageManagementConstants.DefaultMaxDegreeOfParallelism);
 
             CheckRequireConsent();
-            await PackageRestoreManager.RestoreMissingPackagesAsync(
+            var result = await PackageRestoreManager.RestoreMissingPackagesAsync(
                 packageRestoreContext,
                 new ConsoleProjectContext(Console));
 
@@ -364,6 +378,8 @@ namespace NuGet.CommandLine
             {
                 Console.WriteError(item.Exception.Message);
             }
+
+            return result.Restored;
         }
 
         private void CheckRequireConsent()

--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -98,10 +98,6 @@ namespace NuGet.CommandLine
                 {
                     var results = await Task.WhenAll(v3RestoreTasks);
                     restoreResult &= results.All(r => r);
-                    foreach (var result in results)
-                    {
-                        restoreResult &= result;
-                    }
                 }
             }
 

--- a/src/PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/PackageManagement/IDE/PackageRestoreManager.cs
@@ -457,7 +457,7 @@ namespace NuGet.PackageManagement
             while (packageReferencesQueue.TryDequeue(out currentPackageReference))
             {
                 var result = await packageRestoreContext.PackageManager.CopySatelliteFilesAsync(currentPackageReference.PackageIdentity, nuGetProjectContext, packageRestoreContext.Token);
-                copyResult &= true;
+                copyResult &= result;
             }
 
             return copyResult;

--- a/src/PackageManagement/IDE/PackageRestoreManager.cs
+++ b/src/PackageManagement/IDE/PackageRestoreManager.cs
@@ -317,8 +317,13 @@ namespace NuGet.PackageManagement
             await ThrottledCopySatelliteFilesAsync(hashSetOfMissingPackageReferences, packageRestoreContext, nuGetProjectContext);
 
             packageRestoreResult &= restoreResults.All(r => r);
-          
-            return new PackageRestoreResult(packageRestoreResult);
+
+            if (packageRestoreResult)
+            {
+                packageRestoreContext.SetRestored();
+            }
+
+            return new PackageRestoreResult(packageRestoreContext.WasRestored);
         }
 
         /// <summary>

--- a/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1382,5 +1382,47 @@ EndProject";
                 TestFilesystemUtility.DeleteRandomTestFolders(randomTestFolder);
             }
         }
+
+        [Fact]
+        public void RestoreCommand_FromPackagesConfigFileFailed()
+        {
+            // Arrange
+            var tempPath = Path.GetTempPath();
+            var workingPath = Path.Combine(tempPath, Guid.NewGuid().ToString());
+            var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var nugetexe = Util.GetNuGetExePath();
+
+            try
+            {
+                Util.CreateDirectory(workingPath);
+                Util.CreateDirectory(repositoryPath);
+                Util.CreateFile(workingPath, "packages.config",
+@"<packages>
+  <package id=""packageA"" version=""1.1.0"" targetFramework=""net45"" />
+  <package id=""packageB"" version=""2.2.0"" targetFramework=""net45"" />
+</packages>");
+
+                string[] args = new string[] { "restore", "-PackagesDirectory", "outputDir", "-Source", repositoryPath };
+
+                // Act
+                var path = Environment.GetEnvironmentVariable("PATH");
+                Environment.SetEnvironmentVariable("PATH", null);
+                var r = CommandRunner.Run(
+                    nugetexe,
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true);
+                Environment.SetEnvironmentVariable("PATH", path);
+
+                // Assert
+                Assert.Equal(1, r.Item1);
+            }
+            finally
+            {
+                Directory.SetCurrentDirectory(currentDirectory);
+                Util.DeleteDirectory(workingPath);
+            }
+        }
     }
 }

--- a/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetRestoreCommandTest.cs
@@ -1383,6 +1383,7 @@ EndProject";
             }
         }
 
+        // return code should be 1 when restore failed 
         [Fact]
         public void RestoreCommand_FromPackagesConfigFileFailed()
         {


### PR DESCRIPTION
fixed https://github.com/NuGet/Home/issues/1186
the root cause for this bug is we catch the exception in packageManagement layer and packageRestoreResult will be success when there is one package restore succeed.

the fix is get all restore result for each package, and if there is any package restore failed, will throw exception in commandline. then errorlevel will become 1 when package restore failed.
