### PR TITLE
{ProjectName}.project.json support for nuget.exe

### DIFF
--- a/src/ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
+++ b/src/ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
@@ -3,7 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using NuGet.Configuration;
@@ -22,12 +22,17 @@ namespace NuGet.ProjectManagement
         /// <summary>
         /// project.json
         /// </summary>
-        public const string ProjectConfigFileName = "project.json";
+        public static readonly string ProjectConfigFileName = "project.json";
+
+        /// <summary>
+        /// .project.json
+        /// </summary>
+        public static readonly string ProjectConfigFileEnding = ".project.json";
 
         /// <summary>
         /// Lock file name
         /// </summary>
-        public const string ProjectLockFileName = "project.lock.json";
+        public static readonly string ProjectLockFileName = "project.lock.json";
 
         public static string GetEffectiveGlobalPackagesFolder(string solutionDirectory, ISettings settings)
         {
@@ -68,10 +73,127 @@ namespace NuGet.ProjectManagement
 
         /// <summary>
         /// Create the lock file path from the config file path.
+        /// If the config file includes a project name the 
+        /// lock file will include the name also.
         /// </summary>
         public static string GetLockFilePath(string configFilePath)
         {
-            return Path.Combine(Path.GetDirectoryName(configFilePath), ProjectLockFileName);
+            string lockFilePath = null;
+
+            var dir = Path.GetDirectoryName(configFilePath);
+
+            var projectName = GetProjectNameFromConfigFileName(configFilePath);
+
+            if (projectName == null)
+            {
+                lockFilePath = Path.Combine(dir, ProjectLockFileName);
+            }
+            else
+            {
+                var lockFileWithProject = GetProjectLockFileNameWithProjectName(projectName);
+                lockFilePath = Path.Combine(dir, lockFileWithProject);
+            }
+
+            return lockFilePath;
+        }
+
+        /// <summary>
+        /// Creates a projectName.project.json file name.
+        /// </summary>
+        public static string GetProjectConfigWithProjectName(string projectName)
+        {
+            if (String.IsNullOrEmpty(projectName))
+            {
+                throw new ArgumentException(Strings.Argument_Cannot_Be_Null_Or_Empty);
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", projectName, ProjectConfigFileName);
+        }
+
+        /// <summary>
+        /// Creates a projectName.project.json file name.
+        /// </summary>
+        public static string GetProjectLockFileNameWithProjectName(string projectName)
+        {
+            if (String.IsNullOrEmpty(projectName))
+            {
+                throw new ArgumentException(Strings.Argument_Cannot_Be_Null_Or_Empty);
+            }
+
+            return string.Format(CultureInfo.InvariantCulture, "{0}.{1}", projectName, ProjectLockFileName);
+        }
+
+        /// <summary>
+        /// Parses a projectName.project.json file name into a project name.
+        /// If there is no project name null will be returned.
+        /// </summary>
+        public static string GetProjectNameFromConfigFileName(string configPath)
+        {
+            if (configPath == null)
+            {
+                throw new ArgumentNullException(nameof(configPath));
+            }
+
+            var file = Path.GetFileName(configPath);
+
+            string projectName = null;
+
+            if (file != null &&
+                IsProjectConfig(file) &&
+                file.Length >= (ProjectConfigFileName.Length + 1) &&
+                !string.Equals(file, ProjectConfigFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                var prefixLength = file.Length - ProjectConfigFileName.Length - 1;
+                projectName = file.Substring(0, prefixLength);
+            }
+
+            return projectName;
+        }
+
+        /// <summary>
+        /// True if the file is a project.json or projectname.project.json file.
+        /// </summary>
+        public static bool IsProjectConfig(string configPath)
+        {
+            if (configPath == null)
+            {
+                throw new ArgumentNullException(nameof(configPath));
+            }
+
+            var file = Path.GetFileName(configPath);
+
+            return string.Equals(ProjectConfigFileName, file, StringComparison.OrdinalIgnoreCase)
+                || file.EndsWith(ProjectConfigFileEnding, StringComparison.OrdinalIgnoreCase);
+        }
+
+        /// <summary>
+        /// Finds the projectName.project.json in a directory. If no projectName.project.json exists
+        /// the default project.json path will be returned regardless of existance.
+        /// </summary>
+        /// <returns>Returns the full path to the project.json file.</returns>
+        public static string GetProjectConfigPath(string directoryPath, string projectName)
+        {
+            if (String.IsNullOrEmpty(projectName))
+            {
+                throw new ArgumentException(Strings.Argument_Cannot_Be_Null_Or_Empty);
+            }
+
+            // Check for the project name based file first
+            var configPath = Path.Combine(directoryPath, GetProjectConfigWithProjectName(projectName));
+
+            if (!File.Exists(configPath))
+            {
+                // Fallback to project.json
+                configPath = Path.Combine(directoryPath, ProjectConfigFileName);
+
+                if (!File.Exists(configPath))
+                {
+                    // There are no project.json files in this directory
+                    configPath = null;
+                }
+            }
+
+            return configPath;
         }
 
         /// <summary>

--- a/test/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -9,6 +9,199 @@ namespace NuGet.CommandLine.Test
     public class RestoreProjectJsonTest : IDisposable
     {
         [Fact]
+        public void RestoreProjectJson_SolutionFileWithAllProjectsInOneFolder()
+        {
+            // Arrange
+            var tempPath = Path.GetTempPath();
+            var guid = Guid.NewGuid();
+            var workingPath = Path.Combine(tempPath, guid.ToString());
+            var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var projectDir = Path.Combine(workingPath, "abc");
+            var nugetexe = Util.GetNuGetExePath();
+
+            _dirs.TryAdd(workingPath, false);
+
+            Util.CreateDirectory(workingPath);
+            Util.CreateDirectory(repositoryPath);
+            Util.CreateDirectory(projectDir);
+            Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+            var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
+            var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
+
+            var targetA = Util.CreatePackageFile("build/uap/packageA.targets", targetContent);
+            var libA = Util.CreatePackageFile("lib/uap/a.dll", "a");
+
+            packageA.Files.Add(targetA);
+            packageA.Files.Add(libA);
+
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
+            Util.CreateTestPackage(packageA, repositoryPath);
+
+            Util.CreateFile(projectDir, "testA.project.json",
+                                            @"{
+                                            'dependencies': {
+                                            'packageA': '1.1.0-beta-*'
+                                            },
+                                            'frameworks': {
+                                                        'uap10.0': { }
+                                                    }
+                                            }");
+
+            Util.CreateFile(projectDir, "testB.project.json",
+                                            @"{
+                                            'dependencies': {
+                                            'packageA': '1.1.0-beta-*'
+                                            },
+                                            'frameworks': {
+                                                        'uap10.0': { }
+                                                    }
+                                            }");
+
+            Util.CreateFile(projectDir, "packages.testC.config",
+                                            @"<packages>
+                                <package id=""packageA"" version=""1.1.0-beta-01"" targetFramework=""net45"" />
+                            </packages>");
+
+            Util.CreateFile(projectDir, "testA.csproj", CSProjXML); // testA.project.json
+            Util.CreateFile(projectDir, "testB.csproj", CSProjXML); // testB.project.json
+            Util.CreateFile(projectDir, "testC.csproj", CSProjXML); // packages.testC.config
+            Util.CreateFile(projectDir, "testD.csproj", CSProjXML); // Non-nuget
+
+            var slnPath = Path.Combine(workingPath, "xyz.sln");
+
+            Util.CreateFile(workingPath, "xyz.sln",
+                       @"
+                        Microsoft Visual Studio Solution File, Format Version 12.00
+                        # Visual Studio 14
+                        VisualStudioVersion = 14.0.23107.0
+                        MinimumVisualStudioVersion = 10.0.40219.1
+                        Project(""{AAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""testA"", ""abc\testA.csproj"", ""{6A6279C1-B5EE-4C6B-9FA3-A794CE195136}""
+                        EndProject
+                        Project(""{ABE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""testB"", ""abc\testB.csproj"", ""{6A6279C1-B5EE-4C6B-9FA3-A794CE195136}""
+                        EndProject
+                        Project(""{ACE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""testC"", ""abc\testC.csproj"", ""{6A6279C1-B5EE-4C6B-9FA3-A794CE195136}""
+                        EndProject
+                        Project(""{ADE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""testD"", ""abc\testD.csproj"", ""{6A6279C1-B5EE-4C6B-9FA3-A794CE195136}""
+                        EndProject
+                        Global
+                            GlobalSection(SolutionConfigurationPlatforms) = preSolution
+                                Debug|Any CPU = Debug|Any CPU
+                                Release|Any CPU = Release|Any CPU
+                            EndGlobalSection
+                            GlobalSection(ProjectConfigurationPlatforms) = postSolution
+                                {6A6279C1-B5EE-4C6B-9FA3-A794CE195136}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                                {6A6279C1-B5EE-4C6B-9FA3-A794CE195136}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                                {6A6279C1-B5EE-4C6B-9FA3-A794CE195136}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                                {6A6279C1-B5EE-4C6B-9FA3-A794CE195136}.Release|Any CPU.Build.0 = Release|Any CPU
+                            EndGlobalSection
+                            GlobalSection(SolutionProperties) = preSolution
+                                HideSolutionNode = FALSE
+                            EndGlobalSection
+                        EndGlobal
+                        ");
+
+            string[] args = new string[] {
+                "restore",
+                "-Source",
+                repositoryPath,
+                "-solutionDir",
+                workingPath,
+                slnPath
+            };
+
+            var targetFileA = Path.Combine(projectDir, "testA.nuget.targets");
+            var targetFileB = Path.Combine(projectDir, "testB.nuget.targets");
+            var lockFileA = Path.Combine(projectDir, "testA.project.lock.json");
+            var lockFileB = Path.Combine(projectDir, "testB.project.lock.json");
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                workingPath,
+                string.Join(" ", args),
+                waitForExit: true);
+
+            // Assert
+            Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+            Assert.True(File.Exists(targetFileA));
+            Assert.True(File.Exists(targetFileB));
+            Assert.True(File.Exists(lockFileA));
+            Assert.True(File.Exists(lockFileB));
+            Assert.True(File.Exists(Path.Combine(workingPath, "packages/packageA.1.1.0-beta-01/packageA.1.1.0-beta-01.nupkg")));
+        }
+
+        [Fact]
+        public void RestoreProjectJson_GenerateFilesWithProjectNameFromCSProj()
+        {
+            // Arrange
+            var tempPath = Path.GetTempPath();
+            var guid = Guid.NewGuid();
+            var workingPath = Path.Combine(tempPath, guid.ToString());
+            var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var nugetexe = Util.GetNuGetExePath();
+
+            _dirs.TryAdd(workingPath, false);
+
+            Util.CreateDirectory(workingPath);
+            Util.CreateDirectory(repositoryPath);
+            Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+            var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
+            var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
+            var targetA = Util.CreatePackageFile("build/uap/packageA.targets", targetContent);
+            var libA = Util.CreatePackageFile("lib/uap/a.dll", "a");
+            packageA.Files.Add(targetA);
+            packageA.Files.Add(libA);
+
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
+            Util.CreateTestPackage(packageA, repositoryPath);
+
+            Util.CreateFile(workingPath, "test.project.json",
+                                            @"{
+                                            'dependencies': {
+                                            'packageA': '1.1.0-beta-*'
+                                            },
+                                            'frameworks': {
+                                                        'uap10.0': { }
+                                                    }
+                                            }");
+
+            Util.CreateFile(workingPath, "test.csproj",
+                                            @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <Project ToolsVersion=""14.0"" DefaultTargets=""Build""
+                        xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+        <Target Name=""NuGet_GetProjectsReferencingProjectJson""></Target>
+        </Project>");
+
+            var csprojPath = Path.Combine(workingPath, "test.csproj");
+
+            string[] args = new string[] {
+                "restore",
+                "-Source",
+                repositoryPath,
+                "-solutionDir",
+                workingPath,
+                csprojPath
+            };
+
+            var targetFilePath = Path.Combine(workingPath, $"test.nuget.targets");
+            var lockFilePath = Path.Combine(workingPath, $"test.project.lock.json");
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                workingPath,
+                string.Join(" ", args),
+                waitForExit: true);
+
+            // Assert
+            Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+            Assert.True(File.Exists(lockFilePath));
+            Assert.True(File.Exists(targetFilePath));
+        }
+
+        [Fact]
         public void RestoreProjectJson_GenerateTargetsFileFromSln()
         {
             // Arrange
@@ -26,6 +219,7 @@ namespace NuGet.CommandLine.Test
             Util.CreateDirectory(repositoryPath);
             Util.CreateDirectory(projectDir);
             Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
             var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
             var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
 
@@ -125,6 +319,7 @@ namespace NuGet.CommandLine.Test
 
             Util.CreateDirectory(workingPath);
             Util.CreateDirectory(repositoryPath);
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
             Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
             var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
             var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
@@ -209,6 +404,7 @@ namespace NuGet.CommandLine.Test
             Util.CreateDirectory(workingPath);
             Util.CreateDirectory(repositoryPath);
             Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
             var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
             var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
 
@@ -284,6 +480,7 @@ namespace NuGet.CommandLine.Test
             Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
             Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
             Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
             Util.CreateFile(workingPath, "project.json",
                                             @"{
                                             'dependencies': {
@@ -349,6 +546,7 @@ namespace NuGet.CommandLine.Test
             Util.CreateDirectory(workingPath);
             Util.CreateDirectory(repositoryPath);
             Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
             Util.CreateTestPackage("packageA", "1.1.0", repositoryPath);
             Util.CreateTestPackage("packageB", "2.2.0", repositoryPath);
             Util.CreateFile(workingPath, "project.json",
@@ -392,6 +590,12 @@ namespace NuGet.CommandLine.Test
             Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
             Assert.Equal(2, lockFile.Libraries.Count);
         }
+
+        private const string CSProjXML = @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <Project ToolsVersion=""14.0"" DefaultTargets=""Build""
+                        xmlns=""http://schemas.microsoft.com/developer/msbuild/2003"">
+        <Target Name=""NuGet_GetProjectsReferencingProjectJson""></Target>
+        </Project>";
 
         /// <summary>
         /// Store all directories used by the unit tests and clean them up at the end during Dispose()

--- a/test/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.CommandLine.Test/Util.cs
@@ -206,5 +206,16 @@ namespace NuGet.CommandLine.Test
             var nugetexe = Path.Combine(targetDir, "nuget.exe");
             return nugetexe;
         }
+
+        public static void CreateConfigForGlobalPackagesFolder(string workingDirectory)
+        {
+            Util.CreateFile(workingDirectory, "nuget.config",
+                        @"<?xml version=""1.0"" encoding=""utf-8""?>
+                        <configuration>
+                          <config>
+                            <add key=""globalPackagesFolder"" value=""globalPackages"" />
+                          </config>
+                        </configuration>");
+        }
     }
 }

--- a/test/ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging.Core;
+using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.Protocol.Core.Types;
 using NuGet.Versioning;
@@ -18,6 +19,229 @@ namespace ProjectManagement.Test
 {
     public class BuildIntegratedNuGetProjectTests
     {
+        [Fact]
+        public void BuildIntegratedNuGetProject_GetLockFilePathWithProjectNameOnly()
+        {
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var projNameFile = Path.Combine(randomProjectFolderPath, "abc.project.json");
+            CreateFile(projNameFile);
+
+            // Act
+            var path = BuildIntegratedProjectUtility.GetProjectConfigPath(randomProjectFolderPath, "abc");
+            var fileName = Path.GetFileName(path);
+
+            // Assert
+            Assert.Equal(fileName, "abc.project.json");
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath);
+        }
+
+        [Fact]
+        public void BuildIntegratedNuGetProject_GetLockFilePathWithBothProjectJsonFiles()
+        {
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var projNameFile = Path.Combine(randomProjectFolderPath, "abc.project.json");
+            var projJsonFile = Path.Combine(randomProjectFolderPath, "project.json");
+            CreateFile(projNameFile);
+            CreateFile(projJsonFile);
+
+            // Act
+            var path = BuildIntegratedProjectUtility.GetProjectConfigPath(randomProjectFolderPath, "abc");
+            var fileName = Path.GetFileName(path);
+
+            // Assert
+            Assert.Equal(fileName, "abc.project.json");
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath);
+        }
+
+        [Fact]
+        public void BuildIntegratedNuGetProject_GetLockFilePathWithProjectJsonFromAnotherProject()
+        {
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var projNameFile = Path.Combine(randomProjectFolderPath, "xyz.project.json");
+            var projJsonFile = Path.Combine(randomProjectFolderPath, "project.json");
+            CreateFile(projNameFile);
+            CreateFile(projJsonFile);
+
+            // Act
+            var path = BuildIntegratedProjectUtility.GetProjectConfigPath(randomProjectFolderPath, "abc");
+            var fileName = Path.GetFileName(path);
+
+            // Assert
+            Assert.Equal(fileName, "project.json");
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath);
+        }
+
+        [Fact]
+        public void BuildIntegratedNuGetProject_GetLockFilePathWithProjectNameJsonAndAnotherProject()
+        {
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var otherFile = Path.Combine(randomProjectFolderPath, "xyz.project.json");
+            var projJsonFile = Path.Combine(randomProjectFolderPath, "abc.project.json");
+            CreateFile(otherFile);
+            CreateFile(projJsonFile);
+
+            // Act
+            var path = BuildIntegratedProjectUtility.GetProjectConfigPath(randomProjectFolderPath, "abc");
+            var fileName = Path.GetFileName(path);
+
+            // Assert
+            Assert.Equal(fileName, "abc.project.json");
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath);
+        }
+
+        [Fact]
+        public void BuildIntegratedNuGetProject_GetLockFilePathWithNoFiles()
+        {
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+
+            // Act
+            var path = BuildIntegratedProjectUtility.GetProjectConfigPath(randomProjectFolderPath, "abc");
+
+            // Assert
+            Assert.Null(path);
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath);
+        }
+
+        [Fact]
+        public void BuildIntegratedNuGetProject_GetLockFilePathWithProjectJsonOnly()
+        {
+            // Arrange
+            var randomProjectFolderPath = TestFilesystemUtility.CreateRandomTestFolder();
+            var projJsonFile = Path.Combine(randomProjectFolderPath, "project.json");
+            CreateFile(projJsonFile);
+
+            // Act
+            var path = BuildIntegratedProjectUtility.GetProjectConfigPath(randomProjectFolderPath, "abc");
+            var fileName = Path.GetFileName(path);
+
+            // Assert
+            Assert.Equal(fileName, "project.json");
+
+            // Clean-up
+            TestFilesystemUtility.DeleteRandomTestFolders(randomProjectFolderPath);
+        }
+
+        [Theory]
+        [InlineData("abc", "abc.project.json")]
+        [InlineData("ABC", "ABC.project.json")]
+        [InlineData("A B C", "A B C.project.json")]
+        [InlineData("a.b.c", "a.b.c.project.json")]
+        [InlineData(" ", " .project.json")]
+        public void BuildIntegratedNuGetProject_GetProjectConfigWithProjectName(string projectName, string fileName)
+        {
+            // Arrange & Act
+            var generatedName = BuildIntegratedProjectUtility.GetProjectConfigWithProjectName(projectName);
+
+            // Assert
+            Assert.Equal(fileName, generatedName);
+        }
+
+        [Theory]
+        [InlineData("abc", "abc.project.lock.json")]
+        [InlineData("ABC", "ABC.project.lock.json")]
+        [InlineData("A B C", "A B C.project.lock.json")]
+        [InlineData("a.b.c", "a.b.c.project.lock.json")]
+        [InlineData(" ", " .project.lock.json")]
+        public void BuildIntegratedNuGetProject_GetProjectLockFileNameWithProjectName(
+            string projectName,
+            string fileName)
+        {
+            // Arrange & Act
+            var generatedName = BuildIntegratedProjectUtility.GetProjectLockFileNameWithProjectName(projectName);
+
+            // Assert
+            Assert.Equal(fileName, generatedName);
+        }
+
+        [Theory]
+        [InlineData("abc", "abc.project.json")]
+        [InlineData("ABC", "ABC.project.json")]
+        [InlineData("A B C", "A B C.project.json")]
+        [InlineData("a.b.c", "a.b.c.project.json")]
+        [InlineData(" ", " .project.json")]
+        [InlineData("", ".project.json")]
+        public void BuildIntegratedNuGetProject_GetProjectNameFromConfigFileName(
+            string projectName,
+            string fileName)
+        {
+            // Arrange & Act
+            var result = BuildIntegratedProjectUtility.GetProjectNameFromConfigFileName(fileName);
+
+            // Assert
+            Assert.Equal(projectName, result);
+        }
+
+        [Theory]
+        [InlineData("abc.project.json")]
+        [InlineData("a b c.project.json")]
+        [InlineData("MY LONG PROJECT NAME 234234432.project.json")]
+        [InlineData("packages.config.project.json")]
+        [InlineData("111.project.json")]
+        [InlineData("project.json")]
+        [InlineData("prOject.JSon")]
+        [InlineData("xyz.prOject.JSon")]
+        [InlineData("c:\\users\\project.json")]
+        [InlineData("dir\\project.json")]
+        [InlineData("c:\\users\\abc.project.json")]
+        [InlineData("dir\\abc.project.json")]
+        [InlineData(".\\abc.project.json")]
+        public void BuildIntegratedNuGetProject_IsProjectConfig_True(string path)
+        {
+            // Arrange & Act
+            var result = BuildIntegratedProjectUtility.IsProjectConfig(path);
+
+            // Assert
+            Assert.True(result);
+        }
+
+        [Theory]
+        [InlineData("abcproject.json")]
+        [InlineData("a b c.project.jso")]
+        [InlineData("abc.project..json")]
+        [InlineData("packages.config")]
+        [InlineData("project.json ")]
+        [InlineData("c:\\users\\packages.config")]
+        [InlineData("c:\\users\\abc.project..json")]
+        public void BuildIntegratedNuGetProject_IsProjectConfig_False(string path)
+        {
+            // Arrange & Act
+            var result = BuildIntegratedProjectUtility.IsProjectConfig(path);
+
+            // Assert
+            Assert.False(result);
+        }
+
+        [Theory]
+        [InlineData("project.json", "project.lock.json")]
+        [InlineData("dir/project.json", "dir\\project.lock.json")]
+        [InlineData("c:\\users\\project.json", "c:\\users\\project.lock.json")]
+        [InlineData("abc.project.json", "abc.project.lock.json")]
+        [InlineData("dir/abc.project.json", "dir\\abc.project.lock.json")]
+        [InlineData("c:\\users\\abc.project.json", "c:\\users\\abc.project.lock.json")]
+        public void BuildIntegratedNuGetProject_GetLockFilePath(string configPath, string lockFilePath)
+        {
+            // Arrange & Act
+            var result = BuildIntegratedProjectUtility.GetLockFilePath(configPath);
+
+            // Assert
+            Assert.Equal(lockFilePath, result);
+        }
+
         [Fact]
         public async Task TestBuildIntegratedNuGetProjectInstallPackage()
         {
@@ -172,6 +396,11 @@ namespace ProjectManagement.Test
 
                 return json;
             }
+        }
+
+        private static void CreateFile(string path)
+        {
+            File.OpenWrite(path).WriteByte(0);
         }
     }
 }


### PR DESCRIPTION
This change adds support for restoring project.json files containing the project name with nuget.exe.

BuildIntegratedProjectUtility contains common methods for creating and parsing these file names, and also dealing with fallback when both exist. These will be used in both nuget.exe and the VSIX.

I've also cleaned up the code path for nuget.exe restore <csproj> which had several issues including a problem with determining if the project used project.json.

https://github.com/NuGet/Home/issues/1102
https://github.com/NuGet/Home/issues/1218

//cc @deepakaravindr @MeniZalzman @feiling @yishaigalatzer 
