### PR TITLE
Run command line tests synchronously 

### DIFF
--- a/build/test.targets
+++ b/build/test.targets
@@ -10,8 +10,12 @@
 		File="$(TargetDir)$(AssemblyName).dll.config"
 		Lines="@(Line)"			
 		Overwrite="true"
-		/> 
-	<Message Text="dll to run is $(TargetDir)$(AssemblyName).dll" Importance="high" />
-    <xunit Assemblies="$(TargetDir)$(AssemblyName).dll" />
+		/>
+
+		<Message Text="Running tests synchronously for $(TargetDir)$(AssemblyName).dll" Importance="high" />
+		<xunit Assemblies="$(TargetDir)$(AssemblyName).dll" MaxParallelThreads="1" Condition=" $(XUnitDisableRunInParallel) == 'true' " />
+		
+		<Message Text="Running tests in parallel for $(TargetDir)$(AssemblyName).dll" Importance="high" />
+		<xunit Assemblies="$(TargetDir)$(AssemblyName).dll" Condition=" $(XUnitDisableRunInParallel) == '' OR $(XUnitDisableRunInParallel) == 'false' " />
 </Target>
 </Project>

--- a/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -2,6 +2,7 @@
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <PackagesPath>$(UserProfile)\.nuget\packages</PackagesPath>
+    <XUnitDisableRunInParallel>true</XUnitDisableRunInParallel>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>


### PR DESCRIPTION
Command line tests were designed to run synchronously. They were ported over to PM which uses a newer version of Xunit that defaults to parallel, however there are many issues with these tests such as the use of the machine cache and this is causing random failures every time I run them locally.

I believe this was missed before since running the tests in VS gives a different behavior, and on the CI machine teamcity limits the number of threads and seems to force them to run synchronously also. Only when running these as part of msbuild locally does the issue show up.

In the future we could run these in parallel again by adding test collections or other locking, but for now let's disable parallel for this one test project to make things stable.

//cc @MeniZalzman @feiling @deepakaravindr @yishaigalatzer 
