### PR TITLE
PushCommand-Fixes: Added a lot of tests to cover the following scenarios

### DIFF
--- a/src/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -8728,6 +8728,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This version of nuget.exe does not support pushing packages to package source &apos;{0}&apos;..
+        /// </summary>
+        public static string PushCommand_PushNotSupported {
+            get {
+                return ResourceManager.GetString("PushCommand_PushNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There is no default source, please specify a source..
         /// </summary>
         public static string PushCommandNoSourceError {

--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -6055,4 +6055,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="ListCommand_ListNotSupported" xml:space="preserve">
     <value>This version of nuget.exe does not support listing packages from package source '{0}'.</value>
   </data>
+  <data name="PushCommand_PushNotSupported" xml:space="preserve">
+    <value>This version of nuget.exe does not support pushing packages to package source '{0}'.</value>
+  </data>
 </root>


### PR DESCRIPTION
1. API v3 index without push endpoint
2. API v3 index not available
3. APIKey for push is provided as a switch
4. APIKey for push is provided via config
5. DefaultPushSource is specified via config

Scenario 1 and 4 failed. Fixed them

@yishaigalatzer @emgarten @MeniZalzman @feiling 
