### PR TITLE
CacheContext for project.json restores

### DIFF
--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -224,7 +224,7 @@ namespace NuGet.CommandLine
                 request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
             }
 
-            request.NoCache = NoCache;
+            request.CacheContext.NoCache = NoCache;
 
             // Read the existing lock file, this is needed to support IsLocked=true
             var lockFilePath = BuildIntegratedProjectUtility.GetLockFilePath(projectJsonPath);

--- a/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -73,6 +73,7 @@ namespace NuGet.PackageManagement
             var packageSources = sources.Select(source => new Configuration.PackageSource(source));
             var request = new RestoreRequest(packageSpec, packageSources, effectiveGlobalPackagesFolder);
             request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
+            request.CacheContext = cacheContext;
 
             // Add the existing lock file if it exists
             var lockFilePath = BuildIntegratedProjectUtility.GetLockFilePath(project.JsonConfigPath);

--- a/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
+++ b/src/PackageManagement/BuildIntegration/BuildIntegratedRestoreUtility.cs
@@ -10,12 +10,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Commands;
-using NuGet.Configuration;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
 using NuGet.ProjectManagement.Projects;
 using NuGet.ProjectModel;
+using NuGet.Protocol.Core.Types;
 
 namespace NuGet.PackageManagement
 {
@@ -41,6 +41,7 @@ namespace NuGet.PackageManagement
                 logger,
                 sources,
                 effectiveGlobalPackagesFolder,
+                new SourceCacheContext(),
                 token);
 
             // Throw before writing if this has been canceled
@@ -61,6 +62,7 @@ namespace NuGet.PackageManagement
             Logging.ILogger logger,
             IEnumerable<string> sources,
             string effectiveGlobalPackagesFolder,
+            SourceCacheContext cacheContext,
             CancellationToken token)
         {
             // Restoring packages

--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -1370,6 +1370,14 @@ namespace NuGet.PackageManagement
                 rawPackageSpec = JObject.Load(reader);
             }
 
+            // For installs only use cache entries newer than the current time.
+            // This is needed for scenarios where a new package shows up in search
+            // but a previous cache entry does not yet have it.
+            var cacheContext = new SourceCacheContext()
+            {
+                ListMaxAge = DateTimeOffset.UtcNow
+            };
+
             var logger = new ProjectContextLogger(nuGetProjectContext);
 
             var effectiveGlobalPackagesFolder = BuildIntegratedProjectUtility.GetEffectiveGlobalPackagesFolder(
@@ -1390,6 +1398,7 @@ namespace NuGet.PackageManagement
                     logger,
                     sources,
                     effectiveGlobalPackagesFolder,
+                    cacheContext,
                     token);
 
                 originalLockFile = originalRestoreResult.LockFile;
@@ -1419,6 +1428,7 @@ namespace NuGet.PackageManagement
                 logger,
                 sources,
                 effectiveGlobalPackagesFolder,
+                cacheContext,
                 token);
 
             return new BuildIntegratedProjectAction(nuGetProjectActions.First().PackageIdentity,

--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -1548,14 +1548,21 @@ namespace NuGet.PackageManagement
                 // Restore parent projects. These will be updated to include the transitive changes.
                 var parents = await BuildIntegratedRestoreUtility.GetParentProjectsInClosure(SolutionManager, buildIntegratedProject);
 
+                var cacheContext = new SourceCacheContext()
+                {
+                    ListMaxAge = DateTimeOffset.UtcNow
+                };
+
                 foreach (var parent in parents)
                 {
                     // Restore and commit the lock file to disk regardless of the result
                     var parentResult = await BuildIntegratedRestoreUtility.RestoreAsync(
                         parent,
+                        parent.PackageSpec,
                         logger,
                         projectAction.Sources,
                         effectiveGlobalPackagesFolder,
+                        cacheContext,
                         token);
                 }
             }


### PR DESCRIPTION
This adds support for SourceCacheContext when restoring project.json projects. Cache entries older than the start of the operation will be cleared from v3-cache, allowing discovery of the latest package in scenarios where an older restore had already cached them.

https://github.com/NuGet/Home/issues/1096

//cc @yishaigalatzer @feiling @MeniZalzman @deepakaravindr 
