### PR TITLE
Rollback fix for build integrated project operations

### DIFF
--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -1454,8 +1454,11 @@ namespace NuGet.PackageManagement
                     token);
             }
 
-            var uninstallOnly = projectAction.GetProjectActions()
-                .All(action => action.NuGetProjectActionType == NuGetProjectActionType.Uninstall);
+            var actions = projectAction.GetProjectActions();
+
+            // Check if all actions are uninstalls
+            var uninstallOnly = projectAction.NuGetProjectActionType == NuGetProjectActionType.Uninstall
+                && actions.All(action => action.NuGetProjectActionType == NuGetProjectActionType.Uninstall);
 
             var restoreResult = projectAction.RestoreResult;
 


### PR DESCRIPTION
A 3.2.0 fix to skip rollbacks for uninstall caused rollbacks to be skipped in some install and update scenarios. This contains a fix and functional tests for project.json rollbacks.

//cc @deepakaravindr @feiling @MeniZalzman @yishaigalatzer 
