### PR TITLE
nuget.exe list does not handle a non-uri input for source

### DIFF
--- a/src/NuGet.CommandLine/Common/PackageSourceProviderExtensions.cs
+++ b/src/NuGet.CommandLine/Common/PackageSourceProviderExtensions.cs
@@ -14,6 +14,7 @@ namespace NuGet.Common
 
             if (resolvedSource == null)
             {
+                CommandLineUtility.ValidateSource(source);
                 return new Configuration.PackageSource(source);
             }
             else

--- a/test/NuGet.CommandLine.Test/NuGetListCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetListCommandTest.cs
@@ -788,5 +788,141 @@ namespace NuGet.CommandLine.Test
                 TestFilesystemUtility.DeleteRandomTestFolders(packageDirectory);
             }
         }
+
+        [Theory]
+        [InlineData("invalid")]
+        public void ListCommand_InvalidInput_NonSource(string invalidInput)
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Act
+            var args = "list test -Source " + invalidInput;
+            var result = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                args,
+                waitForExit: true);
+
+            // Assert
+            Assert.True(
+                result.Item1 != 0,
+                "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+            Assert.True(
+                result.Item3.Contains(
+                    string.Format(
+                        "The specified source '{0}' is invalid. Please provide a valid source.",
+                        invalidInput)),
+                "Expected error message not found in " + result.Item3
+                );
+        }
+
+        [Theory]
+        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org")]
+        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org/api/v2")]
+        public void ListCommand_InvalidInput_V2_NonExistent(string invalidInput)
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Act
+            var args = "list test -Source " + invalidInput;
+            var result = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                args,
+                waitForExit: true);
+
+            // Assert
+            Assert.True(
+                result.Item1 != 0,
+                "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+            Assert.True(
+                result.Item3.Contains(
+                    "The remote name could not be resolved: 'invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org'"),
+                "Expected error message not found in " + result.Item3
+                );
+        }
+
+        [Theory]
+        [InlineData("https://nuget.org/api/blah")]
+        public void ListCommand_InvalidInput_V2_NotFound(string invalidInput)
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Act
+            var args = "list test -Source " + invalidInput;
+            var result = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                args,
+                waitForExit: true);
+
+            // Assert
+            Assert.True(
+                result.Item1 != 0,
+                "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+            Assert.True(
+                result.Item3.Contains(
+                    "The remote server returned an error: (404) Not Found."),
+                "Expected error message not found in " + result.Item3
+                );
+        }
+
+        [Theory]
+        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org/v3/index.json")]
+        public void ListCommand_InvalidInput_V3_NonExistent(string invalidInput)
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Act
+            var args = "list test -Source " + invalidInput;
+            var result = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                args,
+                waitForExit: true);
+
+            // Assert
+            Assert.True(
+                result.Item1 != 0,
+                "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+            Assert.True(
+                result.Item3.Contains("An error occurred while sending the request."),
+                "Expected error message not found in " + result.Item3
+                );
+        }
+
+        [Theory]
+        [InlineData("https://api.nuget.org/v4/index.json")]
+        public void ListCommand_InvalidInput_V3_NotFound(string invalidInput)
+        {
+            // Arrange
+            var nugetexe = Util.GetNuGetExePath();
+
+            // Act
+            var args = "list test -Source " + invalidInput;
+            var result = CommandRunner.Run(
+                nugetexe,
+                Directory.GetCurrentDirectory(),
+                args,
+                waitForExit: true);
+
+            // Assert
+            Assert.True(
+                result.Item1 != 0,
+                "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+            Assert.True(
+                result.Item3.Contains("The remote server returned an error: (400) Bad Request."),
+                "Expected error message not found in " + result.Item3
+                );
+        }
     }
 }

--- a/test/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetPushCommandTest.cs
@@ -1308,6 +1308,228 @@ namespace NuGet.CommandLine.Test
             }
         }
 
+        [Theory]
+        [InlineData("invalid")]
+        public void PushCommand_InvalidInput_NonSource(string invalidInput)
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var packagesDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                // Arrange
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packagesDirectory);
+
+                // Act
+                var args = new string[]
+                {
+                        "push",
+                        packageFileName,
+                        "-Source",
+                        invalidInput
+                };
+
+                var result = CommandRunner.Run(
+                                nugetexe,
+                                Directory.GetCurrentDirectory(),
+                                string.Join(" ", args),
+                                true);
+
+                // Assert
+                Assert.True(
+                    result.Item1 != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+                Assert.True(
+                    result.Item3.Contains(
+                        string.Format(
+                            "The specified source '{0}' is invalid. Please provide a valid source.",
+                            invalidInput)),
+                    "Expected error message not found in " + result.Item3
+                    );
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(packagesDirectory);
+            }
+        }
+
+        [Theory]
+        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org")]
+        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org/api/v2")]
+        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org/api/v2/Package")]
+        public void PushCommand_InvalidInput_V2HttpSource(string invalidInput)
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var packagesDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                // Arrange
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packagesDirectory);
+
+                // Act
+                var args = new string[]
+                {
+                        "push",
+                        packageFileName,
+                        "-Source",
+                        invalidInput
+                };
+
+                var result = CommandRunner.Run(
+                                nugetexe,
+                                Directory.GetCurrentDirectory(),
+                                string.Join(" ", args),
+                                true);
+
+                // Assert
+                Assert.True(
+                    result.Item1 != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+                Assert.True(
+                    result.Item3.Contains(
+                        "The remote name could not be resolved: 'invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org'"),
+                    "Expected error message not found in " + result.Item3
+                    );
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(packagesDirectory);
+            }
+        }
+
+        [Theory]
+        [InlineData("https://nuget.org/api/blah")]
+        public void PushCommand_InvalidInput_V2_NonExistent(string invalidInput)
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var packagesDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                // Arrange
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packagesDirectory);
+
+                // Act
+                var args = new string[]
+                {
+                        "push",
+                        packageFileName,
+                        "-Source",
+                        invalidInput
+                };
+
+                var result = CommandRunner.Run(
+                                nugetexe,
+                                Directory.GetCurrentDirectory(),
+                                string.Join(" ", args),
+                                true);
+
+                // Assert
+                Assert.True(
+                    result.Item1 != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+                Assert.True(
+                    result.Item3.Contains(
+                        "The remote server returned an error: (404) Not Found."),
+                    "Expected error message not found in " + result.Item3
+                    );
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(packagesDirectory);
+            }
+        }
+
+        [Theory]
+        [InlineData("https://invalid-2a0358f1-88f2-48c0-b68a-bb150cac00bd.org/v3/index.json")]
+        public void PushCommand_InvalidInput_V3_NonExistent(string invalidInput)
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var packagesDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                // Arrange
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packagesDirectory);
+
+                // Act
+                var args = new string[]
+                {
+                        "push",
+                        packageFileName,
+                        "-Source",
+                        invalidInput
+                };
+
+                var result = CommandRunner.Run(
+                                nugetexe,
+                                Directory.GetCurrentDirectory(),
+                                string.Join(" ", args),
+                                true);
+
+                // Assert
+                Assert.True(
+                    result.Item1 != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+                Assert.True(
+                    result.Item3.Contains("An error occurred while sending the request."),
+                    "Expected error message not found in " + result.Item3
+                    );
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(packagesDirectory);
+            }
+        }
+
+        [Theory]
+        [InlineData("https://api.nuget.org/v4/index.json")]
+        public void PushCommand_InvalidInput_V3_NotFound(string invalidInput)
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var packagesDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                // Arrange
+                var packageFileName = Util.CreateTestPackage("testPackage1", "1.1.0", packagesDirectory);
+
+                // Act
+                var args = new string[]
+                {
+                        "push",
+                        packageFileName,
+                        "-Source",
+                        invalidInput
+                };
+
+                var result = CommandRunner.Run(
+                                nugetexe,
+                                Directory.GetCurrentDirectory(),
+                                string.Join(" ", args),
+                                true);
+
+                // Assert
+                Assert.True(
+                    result.Item1 != 0,
+                    "The run did not fail as desired. Simply got this output:" + result.Item2);
+
+                Assert.True(
+                    result.Item3.Contains("The remote server returned an error: (400) Bad Request."),
+                    "Expected error message not found in " + result.Item3
+                    );
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(packagesDirectory);
+            }
+        }
+
         // Asserts that the contents of two files are equal.
         void AssertFileEqual(string fileName1, string fileName2)
         {


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1270 (part of it)
1. Needs to validate invalid input in case of nuget.exe list. nuget.exe push already does that

Apart from that, variety of invalid input values are possible

Since NuGet3 does not handle
1. different network errors and
2. NuGet.Protocol v3 resources uses HttpClient and v2 resources uses
HttpWebRequest via NuGet.Core, the error messages showing up for the same
kind of invalid input is different too

Added tests to assert the various errors shown

@yishaigalatzer @emgarten @feiling @MeniZalzman 
