### PR TITLE
Persist packages.config attributes on package updates

### DIFF
--- a/src/NuGet.CommandLine/Common/ConsoleProjectContext.cs
+++ b/src/NuGet.CommandLine/Common/ConsoleProjectContext.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using System.Xml.Linq;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 
@@ -16,6 +17,8 @@ namespace NuGet.CommandLine
         public ExecutionContext ExecutionContext => null;
 
         public PackageExtractionContext PackageExtractionContext { get; set; }
+
+        public XDocument OriginalPackagesConfig { get; set; }
 
         public ISourceControlManagerProvider SourceControlManagerProvider => null;
 

--- a/src/PackageManagement.UI/Actions/ProjectContext.cs
+++ b/src/PackageManagement.UI/Actions/ProjectContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Xml.Linq;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 
@@ -21,6 +22,8 @@ namespace NuGet.PackageManagement.UI
         }
 
         public PackageExtractionContext PackageExtractionContext { get; set; }
+
+        public XDocument OriginalPackagesConfig { get; set; }
 
         public ISourceControlManagerProvider SourceControlManagerProvider
         {

--- a/src/PackageManagement.UI/Common/PackageRestoreBar.xaml.cs
+++ b/src/PackageManagement.UI/Common/PackageRestoreBar.xaml.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
+using System.Xml.Linq;
 using Microsoft.VisualStudio.Shell;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
@@ -30,6 +31,8 @@ namespace NuGet.PackageManagement.UI
         public ISourceControlManagerProvider SourceControlManagerProvider { get; }
 
         public ProjectManagement.ExecutionContext ExecutionContext { get; }
+
+        public XDocument OriginalPackagesConfig { get; set; }
 
         public PackageRestoreBar(ISolutionManager solutionManager, IPackageRestoreManager packageRestoreManager)
         {

--- a/src/PackageManagement.UI/Common/RestartRequestBar.xaml.cs
+++ b/src/PackageManagement.UI/Common/RestartRequestBar.xaml.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Threading;
+using System.Xml.Linq;
 using Microsoft.VisualStudio.Shell.Interop;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
@@ -29,6 +30,8 @@ namespace NuGet.PackageManagement.UI
         public ISourceControlManagerProvider SourceControlManagerProvider { get; }
 
         public ProjectManagement.ExecutionContext ExecutionContext { get; }
+
+        public XDocument OriginalPackagesConfig { get; set; }
 
         public RestartRequestBar(IDeleteOnRestartManager deleteOnRestartManager, IVsShell4 vsRestarter)
         {

--- a/src/PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
+++ b/src/PackageManagement.UI/UserInterfaceService/NuGetUIProjectContext.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Windows.Threading;
+using System.Xml.Linq;
 using NuGet.Packaging;
 using NuGet.ProjectManagement;
 
@@ -90,6 +91,8 @@ namespace NuGet.PackageManagement.UI
         public ICommonOperations CommonOperations { get; }
 
         public ExecutionContext ExecutionContext { get; }
+
+        public XDocument OriginalPackagesConfig { get; set; }
 
         public void ReportError(string message)
         {

--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -1241,6 +1241,14 @@ namespace NuGet.PackageManagement
             }
             else
             {
+                // Set the original packages config if it exists
+                var msbuildProject = nuGetProject as MSBuildNuGetProject;
+                if (msbuildProject != null)
+                {
+                    nuGetProjectContext.OriginalPackagesConfig = 
+                        msbuildProject.PackagesConfigNuGetProject?.GetPackagesConfig();
+                }
+
                 ExceptionDispatchInfo exceptionInfo = null;
                 var executedNuGetProjectActions = new Stack<NuGetProjectAction>();
                 var packageWithDirectoriesToBeDeleted = new HashSet<PackageIdentity>(PackageIdentity.Comparer);

--- a/src/ProjectManagement/EmptyNuGetProjectContext.cs
+++ b/src/ProjectManagement/EmptyNuGetProjectContext.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System;
+using System.Xml.Linq;
 using NuGet.Packaging;
 
 namespace NuGet.ProjectManagement
@@ -28,6 +30,8 @@ namespace NuGet.ProjectManagement
         {
             get { return null; }
         }
+
+        public XDocument OriginalPackagesConfig { get; set; }
 
         public void ReportError(string message)
         {

--- a/src/ProjectManagement/INuGetProjectContext.cs
+++ b/src/ProjectManagement/INuGetProjectContext.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) .NET Foundation. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using System.Xml.Linq;
 using NuGet.Packaging;
 
 namespace NuGet.ProjectManagement
@@ -25,6 +26,12 @@ namespace NuGet.ProjectManagement
         PackageExtractionContext PackageExtractionContext { get; set; }
         ISourceControlManagerProvider SourceControlManagerProvider { get; }
         ExecutionContext ExecutionContext { get; }
+
+        /// <summary>
+        /// The original packages.config. This is set by package management
+        /// before the actions are executed.
+        /// </summary>
+        XDocument OriginalPackagesConfig { get; set; }
     }
 
     /// <summary>

--- a/src/ProjectManagement/Projects/PackagesConfigNuGetProject.cs
+++ b/src/ProjectManagement/Projects/PackagesConfigNuGetProject.cs
@@ -9,6 +9,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using System.Xml.Linq;
 using NuGet.Frameworks;
 using NuGet.Packaging;
@@ -112,7 +113,18 @@ namespace NuGet.ProjectManagement
                     using (var stream = FileSystemUtility.GetFileStream(FullPath))
                     {
                         var writer = new PackagesConfigWriter(stream, createNew: false);
-                        writer.AddPackageEntry(newPackageReference);
+
+                        if (nuGetProjectContext.OriginalPackagesConfig == null)
+                        {
+                            // Write a new entry
+                            writer.AddPackageEntry(newPackageReference);
+                        }
+                        else
+                        {
+                            // Update the entry based on the original entry if it exists
+                            writer.UpdatePackageEntry(nuGetProjectContext.OriginalPackagesConfig, newPackageReference);
+                        }
+
                         writer.Close();
                     }
                 }
@@ -123,7 +135,18 @@ namespace NuGet.ProjectManagement
                 using (var stream = FileSystemUtility.CreateFile(FullPath, nuGetProjectContext))
                 {
                     var writer = new PackagesConfigWriter(stream, createNew: true);
-                    writer.AddPackageEntry(newPackageReference);
+
+                    if (nuGetProjectContext.OriginalPackagesConfig == null)
+                    {
+                        // Write a new entry
+                        writer.AddPackageEntry(newPackageReference);
+                    }
+                    else
+                    {
+                        // Update the entry based on the original entry if it exists
+                        writer.UpdatePackageEntry(nuGetProjectContext.OriginalPackagesConfig, newPackageReference);
+                    }
+
                     writer.Close();
                 }
             }
@@ -182,6 +205,32 @@ namespace NuGet.ProjectManagement
             return Task.FromResult<IEnumerable<PackageReference>>(GetInstalledPackagesList());
         }
 
+        /// <summary>
+        /// Retrieve the packages.config XML.
+        /// This will return null if the file does not exist.
+        /// </summary>
+        public XDocument GetPackagesConfig()
+        {
+            UpdateFullPath();
+            if (File.Exists(FullPath))
+            {
+                try
+                {
+                    return XDocument.Load(FullPath);
+                }
+                catch (XmlException ex)
+                {
+                    throw new InvalidOperationException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.ErrorLoadingPackagesConfig,
+                        FullPath,
+                        ex.Message));
+                }
+            }
+
+            return null;
+        }
+
         private void UpdateFullPath()
         {
             if (UsingPackagesProjectNameConfigPath
@@ -199,30 +248,25 @@ namespace NuGet.ProjectManagement
 
         private List<PackageReference> GetInstalledPackagesList()
         {
-            UpdateFullPath();
-            if (File.Exists(FullPath))
+            try
             {
-                try
+                var xml = GetPackagesConfig();
+
+                if (xml != null)
                 {
-                    var reader = new PackagesConfigReader(XDocument.Load(FullPath));
+                    var reader = new PackagesConfigReader(xml);
                     return reader.GetPackages().ToList();
                 }
-                catch (Exception ex)
-                {
-                    if (ex is System.Xml.XmlException ||
+            }
+            catch (Exception ex) 
+                when (ex is System.Xml.XmlException ||
                         ex is PackagesConfigReaderException)
-                    {
-                        throw new InvalidOperationException(string.Format(
-                            CultureInfo.CurrentCulture,
-                            Strings.ErrorLoadingPackagesConfig,
-                            FullPath,
-                            ex.Message));
-                    }
-                    else
-                    {
-                        throw;
-                    }
-                }
+            {
+                throw new InvalidOperationException(string.Format(
+                        CultureInfo.CurrentCulture,
+                        Strings.ErrorLoadingPackagesConfig,
+                        FullPath,
+                        ex.Message));
             }
 
             return new List<PackageReference>();

--- a/test/ProjectManagement.Test/ProjectManagement/TestNuGetProjectContext.cs
+++ b/test/ProjectManagement.Test/ProjectManagement/TestNuGetProjectContext.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Xml.Linq;
 using NuGet.Packaging;
 using NuGet.Packaging.Core;
 using NuGet.ProjectManagement;
@@ -36,6 +37,8 @@ namespace Test.Utility
         public bool SkipAssemblyReferences { get; set; }
 
         public bool BindingRedirectsDisabled { get; set; }
+
+        public XDocument OriginalPackagesConfig { get; set; }
 
         public void ReportError(string message)
         {


### PR DESCRIPTION
This change adds the original packages.config file to the project context. During install operations it will be used to reapply the original attributes if there was an entry for the package.

https://github.com/NuGet/Home/issues/1130

//cc @deepakaravindr @MeniZalzman @zhili1208 @yishaigalatzer 
