### PR TITLE
Verify targets files are not removed on multiple restores

### DIFF
--- a/test/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -533,9 +533,12 @@ namespace NuGet.CommandLine.Test
             Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
             Assert.True(File.Exists(targetFilePath));
 
-            var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
-            Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
-            Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+            using (var stream = File.OpenText(targetFilePath))
+            {
+                var targetsFile = stream.ReadToEnd();
+                Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
+                Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+            }
 
             // Act 2
             r = CommandRunner.Run(
@@ -548,9 +551,12 @@ namespace NuGet.CommandLine.Test
             Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
             Assert.True(File.Exists(targetFilePath));
 
-            targetsFile = File.OpenText(targetFilePath).ReadToEnd();
-            Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
-            Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+            using (var stream = File.OpenText(targetFilePath))
+            {
+                var targetsFile = stream.ReadToEnd();
+                Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
+                Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+            }
 
             // Act 3
             r = CommandRunner.Run(
@@ -563,9 +569,12 @@ namespace NuGet.CommandLine.Test
             Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
             Assert.True(File.Exists(targetFilePath));
 
-            targetsFile = File.OpenText(targetFilePath).ReadToEnd();
-            Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
-            Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+            using (var stream = File.OpenText(targetFilePath))
+            {
+                var targetsFile = stream.ReadToEnd();
+                Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
+                Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+            }
         }
 
         [Fact]

--- a/test/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
+++ b/test/NuGet.CommandLine.Test/RestoreProjectJsonTest.cs
@@ -464,6 +464,111 @@ namespace NuGet.CommandLine.Test
         }
 
         [Fact]
+        public void RestoreProjectJson_GenerateTargetsPersistsWithMultipleRestores()
+        {
+            // Arrange
+            var tempPath = Path.GetTempPath();
+            var guid = Guid.NewGuid();
+            var workingPath = Path.Combine(tempPath, guid.ToString());
+            var repositoryPath = Path.Combine(workingPath, Guid.NewGuid().ToString());
+            var currentDirectory = Directory.GetCurrentDirectory();
+            var nugetexe = Util.GetNuGetExePath();
+
+            _dirs.TryAdd(workingPath, false);
+
+            Util.CreateDirectory(workingPath);
+            Util.CreateDirectory(repositoryPath);
+            Util.CreateDirectory(Path.Combine(workingPath, ".nuget"));
+            Util.CreateConfigForGlobalPackagesFolder(workingPath);
+            var packageA = Util.CreateTestPackageBuilder("packageA", "1.1.0-beta-01");
+            var packageB = Util.CreateTestPackageBuilder("packageB", "2.2.0-beta-02");
+
+            var targetContent = "<?xml version=\"1.0\" encoding=\"utf-8\"?><Project ToolsVersion=\"12.0\" xmlns=\"http://schemas.microsoft.com/developer/msbuild/2003\"></Project>";
+
+            var targetA = Util.CreatePackageFile("build/uap/packageA.targets", targetContent);
+            var libA = Util.CreatePackageFile("lib/uap/a.dll", "a");
+
+            packageA.Files.Add(targetA);
+            packageA.Files.Add(libA);
+
+            var targetB = Util.CreatePackageFile("build/uap/packageB.targets", targetContent);
+            var libB = Util.CreatePackageFile("lib/uap/b.dll", "b");
+
+            packageB.Files.Add(targetB);
+            packageB.Files.Add(libB);
+
+            Util.CreateTestPackage(packageA, repositoryPath);
+            Util.CreateTestPackage(packageB, repositoryPath);
+
+            Util.CreateFile(workingPath, "project.json",
+                                            @"{
+                                            'dependencies': {
+                                            'packageA': '1.1.0-beta-*',
+                                            'packageB': '2.2.0-beta-*'
+                                            },
+                                            'frameworks': {
+                                                        'uap10.0': { }
+                                                    }
+                                            }");
+
+            string[] args = new string[] {
+                "restore",
+                "-Source",
+                repositoryPath,
+                "-solutionDir",
+                workingPath,
+                "project.json"
+            };
+
+            var targetFilePath = Path.Combine(workingPath, $"{guid}.nuget.targets");
+
+            // Act
+            var r = CommandRunner.Run(
+                nugetexe,
+                workingPath,
+                string.Join(" ", args),
+                waitForExit: true);
+
+            // Assert
+            Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+            Assert.True(File.Exists(targetFilePath));
+
+            var targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+            Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
+            Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+
+            // Act 2
+            r = CommandRunner.Run(
+                nugetexe,
+                workingPath,
+                string.Join(" ", args),
+                waitForExit: true);
+
+            // Assert 2
+            Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+            Assert.True(File.Exists(targetFilePath));
+
+            targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+            Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
+            Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+
+            // Act 3
+            r = CommandRunner.Run(
+                nugetexe,
+                workingPath,
+                string.Join(" ", args),
+                waitForExit: true);
+
+            // Assert 3
+            Assert.True(0 == r.Item1, r.Item2 + " " + r.Item3);
+            Assert.True(File.Exists(targetFilePath));
+
+            targetsFile = File.OpenText(targetFilePath).ReadToEnd();
+            Assert.True(targetsFile.IndexOf(@"build\uap\packageA.targets") > -1);
+            Assert.True(targetsFile.IndexOf(@"build\uap\packageB.targets") > -1);
+        }
+
+        [Fact]
         public void RestoreProjectJson_IsLockedTrueAfterRestore()
         {
             // Arrange


### PR DESCRIPTION
This test calls nuget.exe restore multiple times and verifies that the targets file exists after each restore.

https://github.com/NuGet/Home/issues/1288

//cc @deepakaravindr @yishaigalatzer 
