### PR TITLE
Ignore invalid project.json config paths

### DIFF
--- a/src/ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
+++ b/src/ProjectManagement/Utility/BuildIntegratedProjectUtility.cs
@@ -157,10 +157,25 @@ namespace NuGet.ProjectManagement
                 throw new ArgumentNullException(nameof(configPath));
             }
 
-            var file = Path.GetFileName(configPath);
+            if (configPath.EndsWith(ProjectConfigFileName, StringComparison.OrdinalIgnoreCase))
+            {
+                string file = null;
 
-            return string.Equals(ProjectConfigFileName, file, StringComparison.OrdinalIgnoreCase)
-                || file.EndsWith(ProjectConfigFileEnding, StringComparison.OrdinalIgnoreCase);
+                try
+                {
+                    file = Path.GetFileName(configPath);
+                }
+                catch
+                {
+                    // ignore invalid paths
+                    return false;
+                }
+
+                return string.Equals(ProjectConfigFileName, file, StringComparison.OrdinalIgnoreCase)
+                        || file.EndsWith(ProjectConfigFileEnding, StringComparison.OrdinalIgnoreCase);
+            }
+
+            return false;
         }
 
         /// <summary>

--- a/test/ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
+++ b/test/ProjectManagement.Test/BuildIntegratedNuGetProjectTests.cs
@@ -218,6 +218,11 @@ namespace ProjectManagement.Test
         [InlineData("project.json ")]
         [InlineData("c:\\users\\packages.config")]
         [InlineData("c:\\users\\abc.project..json")]
+        [InlineData("c:\\users\\")]
+        [InlineData("<Shared>")]
+        [InlineData("<Shared>.Project.json")]
+        [InlineData("\t")]
+        [InlineData("")]
         public void BuildIntegratedNuGetProject_IsProjectConfig_False(string path)
         {
             // Arrange & Act


### PR DESCRIPTION
This adds sanity checking to the configPath and catches any exceptions coming from GetFileName.

https://github.com/NuGet/Home/issues/1316

//cc @yishaigalatzer @deepakaravindr @MeniZalzman 
