### PR TITLE
nuget.exe fails to install or restore without a default feed

### DIFF
--- a/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -102,8 +102,7 @@ namespace NuGet.CommandLine
 
         protected IEnumerable<Configuration.PackageSource> GetPackageSources(Configuration.ISettings settings)
         {
-            var packageSourceProvider = new Configuration.PackageSourceProvider(settings);
-            var availableSources = packageSourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
+            var availableSources = SourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
             var packageSources = new List<Configuration.PackageSource>();
 
             if (!NoCache && !string.IsNullOrEmpty(MachineCache.Default?.Source))

--- a/src/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -164,8 +164,7 @@ namespace NuGet.CommandLine
 
         private SourceRepositoryProvider GetSourceRepositoryProvider()
         {
-            var packageSourceProvider = new Configuration.PackageSourceProvider(Settings);
-            var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider,
+            var sourceRepositoryProvider = new SourceRepositoryProvider(SourceProvider,
                 Enumerable.Concat(
                     Protocol.Core.v2.FactoryExtensionsV2.GetCoreV2(Repository.Provider),
                     Protocol.Core.v3.FactoryExtensionsV2.GetCoreV3(Repository.Provider)));

--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -297,8 +297,7 @@ namespace NuGet.CommandLine
             ReadSettings(packageRestoreInputs);
             var packagesFolderPath = GetPackagesFolder(packageRestoreInputs);
 
-            var packageSourceProvider = new Configuration.PackageSourceProvider(Settings);
-            var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider,
+            var sourceRepositoryProvider = new SourceRepositoryProvider(SourceProvider,
                 Enumerable.Concat(
                     Protocol.Core.v2.FactoryExtensionsV2.GetCoreV2(Repository.Provider),
                     Protocol.Core.v3.FactoryExtensionsV2.GetCoreV3(Repository.Provider)));

--- a/src/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -209,8 +209,7 @@ namespace NuGet.CommandLine
 
         private IEnumerable<Configuration.PackageSource> GetPackageSources()
         {
-            var packageSourceProvider = new Configuration.PackageSourceProvider(Settings);
-            var availableSources = packageSourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
+            var availableSources = SourceProvider.LoadPackageSources().Where(source => source.IsEnabled);
             var packageSources = new List<Configuration.PackageSource>();
             foreach (var source in Source)
             {
@@ -285,8 +284,7 @@ namespace NuGet.CommandLine
 
         private SourceRepositoryProvider GetSourceRepositoryProvider()
         {
-            var packageSourceProvider = new Configuration.PackageSourceProvider(Settings);
-            var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider,
+            var sourceRepositoryProvider = new SourceRepositoryProvider(SourceProvider,
                 Enumerable.Concat(
                     Protocol.Core.v2.FactoryExtensionsV2.GetCoreV2(Repository.Provider),
                     Protocol.Core.v3.FactoryExtensionsV2.GetCoreV3(Repository.Provider)));

--- a/test/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
+++ b/test/NuGet.CommandLine.Test/NuGetInstallCommandTest.cs
@@ -916,7 +916,7 @@ namespace NuGet.CommandLine.Test
                     serverV3.Get.Add("/a/b/c/index.json", r =>
                     {
                         var h = r.Headers["Authorization"];
-                        var credential = String.IsNullOrEmpty(h) ? 
+                        var credential = String.IsNullOrEmpty(h) ?
                             null :
                             System.Text.Encoding.Default.GetString(Convert.FromBase64String(h.Substring(6)));
 
@@ -1009,6 +1009,51 @@ namespace NuGet.CommandLine.Test
             finally
             {
                 // Cleanup
+                TestFilesystemUtility.DeleteRandomTestFolders(randomTestFolder);
+            }
+        }
+
+        [Fact]
+        public void TestInstallWhenNoFeedAvailable()
+        {
+            var nugetexe = Util.GetNuGetExePath();
+            var randomTestFolder = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                // Create an empty config file and pass it as -ConfigFile switch.
+                // This imitates the scenario where there is a machine without a default nuget.config under %APPDATA%
+                var config = string.Format(
+    @"<?xml version='1.0' encoding='utf - 8'?>
+<configuration/>
+");
+                var configFileName = Path.Combine(randomTestFolder, "nuget.config");
+                File.WriteAllText(configFileName, config);
+
+                string[] args = new string[]
+                {
+                        "install Newtonsoft.Json",
+                        "-version",
+                        "7.0.1",
+                        "-ConfigFile",
+                        configFileName
+                };
+
+                var result = CommandRunner.Run(
+                    nugetexe,
+                    randomTestFolder,
+                    string.Join(" ", args),
+                    true);
+
+                var expectedPath = Path.Combine(
+                    randomTestFolder,
+                    "Newtonsoft.Json.7.0.1",
+                    "Newtonsoft.Json.7.0.1.nupkg");
+
+                Assert.True(File.Exists(expectedPath), "nuget.exe did not install Newtonsoft.Json.7.0.1");
+            }
+            finally
+            {
                 TestFilesystemUtility.DeleteRandomTestFolders(randomTestFolder);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1317

nuget.exe should simply use the SourceProvider set by the Command class. Instead, a new instance of Configuration.PackageSourceProvider was being created without the default source values

@yishaigalatzer @emgarten @MeniZalzman @feiling 
