### PR TITLE
Adding command line tests for project.json restore scenarios with prerelease versions

### DIFF
--- a/build/common.props
+++ b/build/common.props
@@ -29,7 +29,7 @@
 	
 	<!--Setting the product information for Beta builds-->
 	<PropertyGroup>
-		<PreReleaseInformationVersion>-RC-$(PreReleaseVersion)</PreReleaseInformationVersion>
+		<PreReleaseInformationVersion>-rc-$(PreReleaseVersion)</PreReleaseInformationVersion>
 	</PropertyGroup>
 	
 	<!--Not using the build number for FileVersion on release build-->


### PR DESCRIPTION
This adds tests for https://github.com/NuGet/Home/issues/1304 and other resolver scenarios involving stable and prerelease packages.

//cc @deepakaravindr @feiling @yishaigalatzer @MeniZalzman @zhili1208 
