### PR TITLE
nuget.exe restore <projectFileName>, where the project contains a packages.config works now

### DIFF
--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -491,7 +491,7 @@ namespace NuGet.CommandLine
                     else if (File.Exists(packagesConfigPath))
                     {
                         // Check for packages.config
-                        packageRestoreInputs.PackageReferenceFiles.Add(projectFilePath);
+                        packageRestoreInputs.PackageReferenceFiles.Add(packagesConfigPath);
                     }
                 }
                 else


### PR DESCRIPTION
Fixes https://github.com/NuGet/Home/issues/1313

nuget.exe restore < projectFileName >, where the project contains a
packages.config works now

@yishaigalatzer @MeniZalzman @emgarten @feiling @zhili1208 
