### PR TITLE
Fix NuGet/Home#1336: Msbuild selection in nuget.exe 3.2 RC is broken

### DIFF
--- a/src/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -322,7 +322,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to MSBuild 4.0..
+        ///   Looks up a localized string similar to Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the highest installed version of MSBuild is used..
         /// </summary>
         internal static string CommandMSBuildVersion {
             get {

--- a/src/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.CommandLine/NuGetCommand.resx
@@ -5243,6 +5243,6 @@ nuget update -Self</value>
     <value>A list of packages sources to use as fallbacks for this command.</value>
   </data>
   <data name="CommandMSBuildVersion" xml:space="preserve">
-    <value>Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to MSBuild 4.0.</value>
+    <value>Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the highest installed version of MSBuild is used.</value>
   </data>
 </root>


### PR DESCRIPTION
nuget runs "msbuild.exe /version" to get the version of msbuild in PATH, then looks in registry
to find the installation path of that version. However, the version number of a recent update of msbuild 4.0
is now 4.6.x.x, which does not match any version in the registry. nuget then fails because it cannot
locate the installation path of msbuild.

Instead of trying to use the msbuild in PATH, nuget now just uses the highest installed version.

@yishaigalatzer @emgarten @deepakaravindr @zhili1208 
