### PR TITLE
Fix NuGet/Home#1336: Msbuild selection in nuget.exe 3.2 RC is broken

### DIFF
--- a/src/NuGet.CommandLine/Commands/PackCommand.cs
+++ b/src/NuGet.CommandLine/Commands/PackCommand.cs
@@ -114,7 +114,7 @@ namespace NuGet.CommandLine
 
         public override void ExecuteCommand()
         {
-            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion);
+            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion, Console);
 
             if (Verbose)
             {

--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -49,7 +49,7 @@ namespace NuGet.CommandLine
         {
             bool restoreResult = true;
 
-            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion);
+            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion, Console);
 
             if (!string.IsNullOrEmpty(PackagesDirectory))
             {

--- a/src/NuGet.CommandLine/Commands/UpdateCommand.cs
+++ b/src/NuGet.CommandLine/Commands/UpdateCommand.cs
@@ -64,7 +64,7 @@ namespace NuGet.CommandLine
                 throw new CommandLineException(NuGetResources.InvalidFile);
             }
 
-            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion);
+            _msbuildDirectory = MsBuildUtility.GetMsbuildDirectory(MSBuildVersion, Console);
             var context = new UpdateConsoleProjectContext(Console, FileConflictAction);
 
             string inputFileName = Path.GetFileName(inputFile);

--- a/src/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.CommandLine/MsBuildUtility.cs
@@ -115,86 +115,178 @@ namespace NuGet.CommandLine
             }
         }
 
-        public static string GetMsbuildDirectory(string version)
+        /// <summary>
+        /// Gets the version of MSBuild in PATH. 
+        /// </summary>
+        /// <returns>The version of MSBuild in PATH. Returns null if MSBuild does not exist in PATH.</returns>
+        private static Version GetMSBuildVersionInPath()
         {
-            if (string.IsNullOrEmpty(version))
+            // run msbuild to get the version
+            var processStartInfo = new ProcessStartInfo
             {
-                // default to 4.0
-                version = "4.0";
+                UseShellExecute = false,
+                FileName = "msbuild.exe",
+                Arguments = "/version",
+                RedirectStandardOutput = true
+            };
 
-                // run msbuild to get the version
-                var processStartInfo = new ProcessStartInfo
+            try
+            {
+                using (var process = Process.Start(processStartInfo))
                 {
-                    UseShellExecute = false,
-                    FileName = "msbuild.exe",
-                    Arguments = "/version",
-                    RedirectStandardOutput = true
-                };
+                    process.WaitForExit(10 * 1000);
 
-                try
-                {
-                    using (var process = Process.Start(processStartInfo))
+                    if (process.ExitCode == 0)
                     {
-                        process.WaitForExit(10 * 1000);
+                        var output = process.StandardOutput.ReadToEnd();
 
-                        if (process.ExitCode == 0)
+                        // The output of msbuid /version with MSBuild 14 is:
+                        //
+                        // Microsoft (R) Build Engine version 14.0.23107.0
+                        // Copyright(C) Microsoft Corporation. All rights reserved.
+                        //
+                        // 14.0.23107.0                            
+                        var lines = output.Split(
+                            new[] { Environment.NewLine },
+                            StringSplitOptions.RemoveEmptyEntries);
+
+                        string versionString = lines.LastOrDefault(
+                            line => !string.IsNullOrWhiteSpace(line));
+                        Version version;
+                        if (Version.TryParse(versionString, out version))
                         {
-                            var output = process.StandardOutput.ReadToEnd();
-
-                            // The output of msbuid /version with MSBuild 14 is:
-                            //
-                            // Microsoft (R) Build Engine version 14.0.23107.0
-                            // Copyright(C) Microsoft Corporation. All rights reserved.
-                            //
-                            // 14.0.23107.0                            
-                            var lines = output.Split(
-                                new[] { Environment.NewLine },
-                                StringSplitOptions.RemoveEmptyEntries);
-
-                            version = lines.LastOrDefault(
-                                line => !string.IsNullOrWhiteSpace(line));
+                            return version;
                         }
                     }
                 }
-                catch
+            }
+            catch
+            {
+                // ignore errors                
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Gets the msbuild toolset that matches the given <paramref name="msbuildVersion"/>.
+        /// </summary>
+        /// <param name="msbuildVersion">The msbuild version. Can be null.</param>
+        /// <param name="installedToolsets">List of installed toolsets, 
+        /// ordered by ToolsVersion, from highest to lowest.</param>
+        /// <returns>The matching toolset.</returns>
+        public static Toolset SelectMsbuildToolset(
+            Version msbuildVersion,
+            IList<Toolset> installedToolsets)
+        {
+            Toolset selectedToolset;
+            if (msbuildVersion == null)
+            {
+                // MSBuild does not exist in PATH. In this case, the highest installed version is used
+                selectedToolset = installedToolsets.First();
+            }
+            else
+            {
+                // Search by major & minor version
+                selectedToolset = installedToolsets.FirstOrDefault(
+                    toolset =>
+                    {
+                        var v = new Version(toolset.ToolsVersion);
+                        return v.Major == msbuildVersion.Major && v.Minor == v.Minor;
+                    });
+
+                if (selectedToolset == null)
                 {
-                    // ignore errors
+                    // no match found. Now search by major only
+                    selectedToolset = installedToolsets.FirstOrDefault(
+                        toolset =>
+                        {
+                            var v = new Version(toolset.ToolsVersion);
+                            return v.Major == msbuildVersion.Major;
+                        });
+                }
+
+                if (selectedToolset == null)
+                {
+                    // still no match. Use the highest installed version in this case
+                    selectedToolset = installedToolsets.First();
                 }
             }
 
-            var versionString = version.Contains('.') ?
-                version :
-                version + ".0";
-            Version ver;
-            if (!Version.TryParse(versionString, out ver))
-            {
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    LocalizedResourceManager.GetString(
-                        nameof(NuGetResources.Error_InvalidMsbuildVersion)),
-                    version);
+            return selectedToolset;
+        }
 
-                throw new CommandLineException(message);
-            }
-
+        public static string GetMsbuildDirectory(string version, IConsole console)
+        {
+            List<Toolset> installedToolsets;
             using (var projectCollection = new ProjectCollection())
             {
-                foreach (var toolset in projectCollection.Toolsets)
+                installedToolsets = projectCollection.Toolsets.OrderByDescending(
+                    toolset => new Version(toolset.ToolsVersion)).ToList();                
+            }
+
+            if (string.IsNullOrEmpty(version))
+            {
+                var msbuildVersion = GetMSBuildVersionInPath();
+                var toolset = SelectMsbuildToolset(msbuildVersion, installedToolsets);
+
+                if (console != null)
                 {
-                    var toolsVersion = new Version(toolset.ToolsVersion);
-                    if (toolsVersion.Major == ver.Major &&
-                        toolsVersion.Minor == ver.Minor)
+                    if (console.Verbosity == Verbosity.Detailed)
                     {
-                        return toolset.ToolsPath;
+                        console.WriteLine(
+                            LocalizedResourceManager.GetString(
+                                nameof(NuGetResources.MSBuildAutoDetection_Verbose)),
+                            toolset.ToolsVersion,
+                            toolset.ToolsPath);
+                    }
+                    else
+                    {
+                        console.WriteLine(
+                            LocalizedResourceManager.GetString(
+                                nameof(NuGetResources.MSBuildAutoDetection)),
+                            toolset.ToolsVersion,
+                            toolset.ToolsPath);
                     }
                 }
 
-                var message = string.Format(
-                    CultureInfo.CurrentCulture,
-                    LocalizedResourceManager.GetString(
-                        nameof(NuGetResources.Error_CannotFindMsbuild)),
-                    version);
-                throw new CommandLineException(message);
+                return toolset.ToolsPath;
+            }
+            else
+            {
+                var versionString = version.Contains('.') ?
+                    version :
+                    version + ".0";
+                Version ver;
+                if (!Version.TryParse(versionString, out ver))
+                {
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString(
+                            nameof(NuGetResources.Error_InvalidMsbuildVersion)),
+                        version);
+
+                    throw new CommandLineException(message);
+                }
+
+                var selectedToolset = installedToolsets.FirstOrDefault(
+                    toolset =>
+                    {
+                        var toolsVersion = new Version(toolset.ToolsVersion);
+                        return (toolsVersion.Major == ver.Major &&
+                            toolsVersion.Minor == ver.Minor);
+                    });
+                if (selectedToolset == null)
+                {
+                    var message = string.Format(
+                        CultureInfo.CurrentCulture,
+                        LocalizedResourceManager.GetString(
+                            nameof(NuGetResources.Error_CannotFindMsbuild)),
+                        version);
+                    throw new CommandLineException(message);
+                }
+
+                return selectedToolset.ToolsPath;
             }
         }
     }

--- a/src/NuGet.CommandLine/MsBuildUtility.cs
+++ b/src/NuGet.CommandLine/MsBuildUtility.cs
@@ -150,7 +150,7 @@ namespace NuGet.CommandLine
                             new[] { Environment.NewLine },
                             StringSplitOptions.RemoveEmptyEntries);
 
-                        string versionString = lines.LastOrDefault(
+                        var versionString = lines.LastOrDefault(
                             line => !string.IsNullOrWhiteSpace(line));
                         Version version;
                         if (Version.TryParse(versionString, out version))
@@ -183,7 +183,7 @@ namespace NuGet.CommandLine
             if (msbuildVersion == null)
             {
                 // MSBuild does not exist in PATH. In this case, the highest installed version is used
-                selectedToolset = installedToolsets.First();
+                selectedToolset = installedToolsets.FirstOrDefault();
             }
             else
             {
@@ -209,8 +209,15 @@ namespace NuGet.CommandLine
                 if (selectedToolset == null)
                 {
                     // still no match. Use the highest installed version in this case
-                    selectedToolset = installedToolsets.First();
+                    selectedToolset = installedToolsets.FirstOrDefault();
                 }
+            }
+
+            if (selectedToolset == null)
+            {
+                throw new CommandLineException(
+                    LocalizedResourceManager.GetString(
+                            nameof(NuGetResources.Error_MSBuildNotInstalled)));
             }
 
             return selectedToolset;

--- a/src/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -322,7 +322,7 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to MSBuild 4.0..
+        ///   Looks up a localized string similar to Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild..
         /// </summary>
         internal static string CommandMSBuildVersion {
             get {

--- a/src/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.CommandLine/NuGetCommand.resx
@@ -5243,6 +5243,6 @@ nuget update -Self</value>
     <value>A list of packages sources to use as fallbacks for this command.</value>
   </data>
   <data name="CommandMSBuildVersion" xml:space="preserve">
-    <value>Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to MSBuild 4.0.</value>
+    <value>Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.</value>
   </data>
 </root>

--- a/src/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -2752,6 +2752,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MSBuild is not installed..
+        /// </summary>
+        public static string Error_MSBuildNotInstalled {
+            get {
+                return ResourceManager.GetString("Error_MSBuildNotInstalled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This folder contains more than one solution file..
         /// </summary>
         public static string Error_MultipleSolutions {

--- a/src/NuGet.CommandLine/NuGetResources.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetResources.Designer.cs
@@ -5947,6 +5947,24 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to MSBuild auto-detection: using msbuild version &apos;{0}&apos; from &apos;{1}&apos;..
+        /// </summary>
+        public static string MSBuildAutoDetection {
+            get {
+                return ResourceManager.GetString("MSBuildAutoDetection", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to MSBuild auto-detection: using msbuild version &apos;{0}&apos; from &apos;{1}&apos;. Use option -MSBuildVersion to force nuget to use a specific version of MSBuild..
+        /// </summary>
+        public static string MSBuildAutoDetection_Verbose {
+            get {
+                return ResourceManager.GetString("MSBuildAutoDetection_Verbose", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MsBuild.exe does not exist at &apos;{0}&apos;..
         /// </summary>
         public static string MsBuildDoesNotExistAtPath {

--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -6064,4 +6064,7 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="MSBuildAutoDetection_Verbose" xml:space="preserve">
     <value>MSBuild auto-detection: using msbuild version '{0}' from '{1}'. Use option -MSBuildVersion to force nuget to use a specific version of MSBuild.</value>
   </data>
+  <data name="Error_MSBuildNotInstalled" xml:space="preserve">
+    <value>MSBuild is not installed.</value>
+  </data>
 </root>

--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -6058,4 +6058,10 @@ Oluşturma sırasında NuGet'in paketleri indirmesini önlemek için, Visual Stu
   <data name="PushCommand_PushNotSupported" xml:space="preserve">
     <value>This version of nuget.exe does not support pushing packages to package source '{0}'.</value>
   </data>
+  <data name="MSBuildAutoDetection" xml:space="preserve">
+    <value>MSBuild auto-detection: using msbuild version '{0}' from '{1}'.</value>
+  </data>
+  <data name="MSBuildAutoDetection_Verbose" xml:space="preserve">
+    <value>MSBuild auto-detection: using msbuild version '{0}' from '{1}'. Use option -MSBuildVersion to force nuget to use a specific version of MSBuild.</value>
+  </data>
 </root>

--- a/test/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -12,9 +12,18 @@ namespace NuGet.CommandLine.Test
         {
             using (var projectCollection = new ProjectCollection())
             {
-                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV14 = new Toolset(
+                    "14.0", "v14path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset(
+                    "12.0", "v12path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset(
+                    "4.0", "v4path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
 
                 var installedToolsets = new List<Toolset> {
                     toolsetV14, toolsetV12, toolsetV4
@@ -34,10 +43,22 @@ namespace NuGet.CommandLine.Test
         {
             using (var projectCollection = new ProjectCollection())
             {
-                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV12_5 = new Toolset("12.5", "v12_5path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV14 = new Toolset(
+                    "14.0", "v14path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV12_5 = new Toolset(
+                    "12.5", "v12_5path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset(
+                    "12.0", "v12path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset(
+                    "4.0", "v4path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
 
                 var installedToolsets = new List<Toolset> {
                     toolsetV14, toolsetV12_5, toolsetV12, toolsetV4
@@ -51,16 +72,25 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        // test that SelectMsbuildToolset returns the toolset that matches the msbuild major version if 
+        // test that SelectMsbuildToolset returns the toolset that matches the msbuild major version if
         // (major + minor) do not match
         [Fact]
         private void VersionSelectedThatMatchesMSBuildVersionMajor()
         {
             using (var projectCollection = new ProjectCollection())
             {
-                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV14 = new Toolset(
+                    "14.0", "v14path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset(
+                    "12.0", "v12path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset(
+                    "4.0", "v4path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
 
                 var installedToolsets = new List<Toolset> {
                     toolsetV14, toolsetV12, toolsetV4
@@ -74,16 +104,25 @@ namespace NuGet.CommandLine.Test
             }
         }
 
-        // test that SelectMsbuildToolset returns the highest version toolset if 
+        // test that SelectMsbuildToolset returns the highest version toolset if
         // there are no matches using major nor (major + minor)
         [Fact]
         private void HighestVersionSelectedIfNoVersionMatch()
         {
             using (var projectCollection = new ProjectCollection())
             {
-                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
-                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV14 = new Toolset(
+                    "14.0", "v14path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset(
+                    "12.0", "v12path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset(
+                    "4.0", "v4path",
+                    projectCollection: projectCollection,
+                    msbuildOverrideTasksPath: null);
 
                 var installedToolsets = new List<Toolset> {
                     toolsetV14, toolsetV12, toolsetV4

--- a/test/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
+++ b/test/NuGet.CommandLine.Test/MSBuildUtilityTest.cs
@@ -1,0 +1,100 @@
+﻿using System.Collections.Generic;
+using Microsoft.Build.Evaluation;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class MSBuildUtilityTest
+    {
+        // test that when msbuildVersion is null, SelectMsbuildToolset returns the highest installed version.
+        [Fact]
+        private void HighestVersionSelectedIfMSBuildVersionIsNull()
+        {
+            using (var projectCollection = new ProjectCollection())
+            {
+                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+
+                var installedToolsets = new List<Toolset> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
+
+                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                    msbuildVersion: null,
+                    installedToolsets: installedToolsets);
+
+                Assert.Equal(selectedToolset, toolsetV14);
+            }
+        }
+
+        // test that SelectMsbuildToolset returns the toolset that matches the msbuild version (major + minor)
+        [Fact]
+        private void VersionSelectedThatMatchesMSBuildVersion()
+        {
+            using (var projectCollection = new ProjectCollection())
+            {
+                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV12_5 = new Toolset("12.5", "v12_5path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+
+                var installedToolsets = new List<Toolset> {
+                    toolsetV14, toolsetV12_5, toolsetV12, toolsetV4
+                };
+
+                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                    msbuildVersion: new System.Version("12.5.4.12"),
+                    installedToolsets: installedToolsets);
+
+                Assert.Equal(selectedToolset, toolsetV12_5);
+            }
+        }
+
+        // test that SelectMsbuildToolset returns the toolset that matches the msbuild major version if 
+        // (major + minor) do not match
+        [Fact]
+        private void VersionSelectedThatMatchesMSBuildVersionMajor()
+        {
+            using (var projectCollection = new ProjectCollection())
+            {
+                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+
+                var installedToolsets = new List<Toolset> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
+
+                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                    msbuildVersion: new System.Version("4.6"),
+                    installedToolsets: installedToolsets);
+
+                Assert.Equal(selectedToolset, toolsetV4);
+            }
+        }
+
+        // test that SelectMsbuildToolset returns the highest version toolset if 
+        // there are no matches using major nor (major + minor)
+        [Fact]
+        private void HighestVersionSelectedIfNoVersionMatch()
+        {
+            using (var projectCollection = new ProjectCollection())
+            {
+                var toolsetV14 = new Toolset("14.0", "v14path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV12 = new Toolset("12.0", "v12path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+                var toolsetV4 = new Toolset("4.0", "v4path", projectCollection: projectCollection, msbuildOverrideTasksPath: null);
+
+                var installedToolsets = new List<Toolset> {
+                    toolsetV14, toolsetV12, toolsetV4
+                };
+
+                var selectedToolset = MsBuildUtility.SelectMsbuildToolset(
+                    msbuildVersion: new System.Version("5.6"),
+                    installedToolsets: installedToolsets);
+
+                Assert.Equal(selectedToolset, toolsetV14);
+            }
+        }
+    }
+}

--- a/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -62,6 +62,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>MockServerResource.resx</DependentUpon>
     </Compile>
+    <Compile Include="MSBuildUtilityTest.cs" />
     <Compile Include="NuGetConfigCommandTest.cs" />
     <Compile Include="NuGetDeleteCommandTest.cs" />
     <Compile Include="NuGetHelpCommandTest.cs" />

--- a/test/NuGet.CommandLine.Test/ProjectFactoryTest.cs
+++ b/test/NuGet.CommandLine.Test/ProjectFactoryTest.cs
@@ -38,7 +38,7 @@ namespace NuGet.CommandLine
                 Authors = "Outercurve Foundation",
             };
             var projectMock = new Mock<Project>();
-            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsbuildDirectory("4.0");
+            var msbuildDirectory = NuGet.CommandLine.MsBuildUtility.GetMsbuildDirectory("4.0", console: null);
             var factory = new ProjectFactory(msbuildDirectory, projectMock.Object);
 
             // act


### PR DESCRIPTION
nuget runs "msbuild.exe /version" to get the version of msbuild in PATH, then matches it with the
installed versions by major and minor version number. However, the version number of a recent update
of msbuild 4.0 is now 4.6.x.x, which does not match an installed version.

The fix is to do match by major number if matching by major + minor fails. nuget also displays the
selected msbuild version on auto detection.

@yishaigalatzer @emgarten @deepakaravindr @zhili1208 @MeniZalzman 
