### PR TITLE
Add download timeout option to restore and install commands

### DIFF
--- a/src/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -43,6 +43,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "InstallCommandSolutionDirectory")]
         public string SolutionDirectory { get; set; }
 
+        [Option(typeof(NuGetCommand), "InstallCommandDownloadTimeout")]
+        public int Timeout { get; set; }
+
         private bool AllowMultipleVersions
         {
             get { return !ExcludeVersion; }
@@ -189,6 +192,15 @@ namespace NuGet.CommandLine
             var packageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, installPath);
 
             var primaryRepositories = GetPackageSources(Settings).Select(sourceRepositoryProvider.CreateRepository);
+
+            // Override the download timeout for package sources if -Timeout is specified
+            if (Timeout > 0)
+            {
+                foreach (var repo in primaryRepositories)
+                {
+                    repo.PackageSource.DownloadTimeout = TimeSpan.FromSeconds(Timeout);
+                }
+            }
 
             var resolutionContext = new ResolutionContext(
                         DependencyBehavior.Lowest,

--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -36,6 +36,9 @@ namespace NuGet.CommandLine
         [Option(typeof(NuGetCommand), "CommandMSBuildVersion")]
         public string MSBuildVersion { get; set; }
 
+        [Option(typeof(NuGetCommand), "RestoreCommandDownloadTimeout")]
+        public int Timeout { get; set; }
+
         [ImportingConstructor]
         public RestoreCommand()
             : base(MachineCache.Default)
@@ -209,6 +212,16 @@ namespace NuGet.CommandLine
             Console.LogVerbose($"Using packages directory: {packagesDir}");
 
             var packageSources = GetPackageSources(Settings);
+             
+            // Override the download timeout for package sources if -Timeout is specified
+            if (Timeout > 0)
+            {
+                foreach (var packageSource in packageSources)
+                {
+                    packageSource.DownloadTimeout = TimeSpan.FromSeconds(Timeout);
+                }
+            }
+
             var request = new RestoreRequest(
                 packageSpec,
                 packageSources);

--- a/src/NuGet.CommandLine/NuGetCommand.Designer.cs
+++ b/src/NuGet.CommandLine/NuGetCommand.Designer.cs
@@ -3346,6 +3346,15 @@ namespace NuGet.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Specifies the timeout for an individual package download in seconds..
+        /// </summary>
+        internal static string InstallCommandDownloadTimeout {
+            get {
+                return ResourceManager.GetString("InstallCommandDownloadTimeout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to If set, the destination folder will contain only the package name, not the version number.
         /// </summary>
         internal static string InstallCommandExcludeVersionDescription {
@@ -9689,6 +9698,15 @@ namespace NuGet.CommandLine {
         internal static string RestoreCommandDisableParallelProcessing_trk {
             get {
                 return ResourceManager.GetString("RestoreCommandDisableParallelProcessing_trk", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Specifies the timeout for an individual package download in seconds..
+        /// </summary>
+        internal static string RestoreCommandDownloadTimeout {
+            get {
+                return ResourceManager.GetString("RestoreCommandDownloadTimeout", resourceCulture);
             }
         }
         

--- a/src/NuGet.CommandLine/NuGetCommand.resx
+++ b/src/NuGet.CommandLine/NuGetCommand.resx
@@ -5245,4 +5245,10 @@ nuget update -Self</value>
   <data name="CommandMSBuildVersion" xml:space="preserve">
     <value>Specifies the version of MSBuild to be used with this command. Supported values are 4, 12, 14. By default the MSBuild in your path is picked, otherwise it defaults to the highest installed version of MSBuild.</value>
   </data>
+  <data name="InstallCommandDownloadTimeout" xml:space="preserve">
+    <value>Specifies the timeout for an individual package download in seconds.</value>
+  </data>
+  <data name="RestoreCommandDownloadTimeout" xml:space="preserve">
+    <value>Specifies the timeout for an individual package download in seconds.</value>
+  </data>
 </root>


### PR DESCRIPTION
Builds on NuGet/NuGet3#128 by allowing a command line option -Timeout to override the download timeout on a package source, for install and restore commands.
