### PR TITLE
nuget.exe restore command input validation fixes

### DIFF
--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -103,7 +103,7 @@ namespace NuGet.CommandLine
 
             if (!restoreResult)
             {
-                throw new CommandLineException();
+                throw new ExitCodeException(exitCode: 1);
             }
         }
 
@@ -148,8 +148,10 @@ namespace NuGet.CommandLine
         private async Task<bool> PerformNuGetV3RestoreAsync(string packagesDir, string inputPath)
         {
             var inputFileName = Path.GetFileName(inputPath);
-            PackageSpec packageSpec;
+            var projectDirectory = Path.GetDirectoryName(Path.GetFullPath(inputPath));
+            PackageSpec packageSpec = null;
             string projectJsonPath = null;
+            string projectName = null;
 
             // Determine the type of the input and restore it appropriately
             // Inputs can be: project.json files or msbuild project files
@@ -159,108 +161,105 @@ namespace NuGet.CommandLine
             {
                 // Restore a project.json file using the directory as the Id
                 Console.LogVerbose($"Reading project file {Arguments[0]}");
-                var projectDirectory = Path.GetDirectoryName(inputPath);
 
                 projectJsonPath = inputPath;
-
-                packageSpec = JsonPackageSpecReader.GetPackageSpec(
-                    File.ReadAllText(projectJsonPath),
-                    Path.GetFileName(projectDirectory),
-                    projectJsonPath);
+                projectName = Path.GetFileName(projectDirectory);
             }
-            else if (MsBuildUtility.IsMsBuildBasedProject(inputPath))
+            else if (ProjectHelper.UnsupportedProjectExtensions.Contains(Path.GetExtension(inputPath)))
             {
-                // Restore a .csproj or other msbuild project file using the 
-                // file name without the extension as the Id
-                externalProjects = MsBuildUtility.GetProjectReferences(_msbuildDirectory, inputPath);
-
-                var projectDirectory = Path.GetDirectoryName(Path.GetFullPath(inputPath));
-                var projectName = Path.GetFileNameWithoutExtension(inputPath);
+                // Unsupported projects such as DNX's .xproj are a noop and should
+                // be treated as a success.
+                return true;
+            }
+            else
+            {
+                projectName = Path.GetFileNameWithoutExtension(inputPath);
                 projectJsonPath = BuildIntegratedProjectUtility.GetProjectConfigPath(projectDirectory, projectName);
 
+                // For known project types that support the msbuild p2p reference task find all project references.
+                if (MsBuildUtility.IsMsBuildBasedProject(inputPath))
+                {
+                    // Restore a .csproj or other msbuild project file using the 
+                    // file name without the extension as the Id
+                    externalProjects = MsBuildUtility.GetProjectReferences(_msbuildDirectory, inputPath);
+                }
+            }
+
+            var success = false;
+
+            if (projectJsonPath != null && File.Exists(projectJsonPath))
+            {
                 Console.LogVerbose($"Reading project file {inputPath}");
 
                 packageSpec = JsonPackageSpecReader.GetPackageSpec(
                     File.ReadAllText(projectJsonPath),
                     projectName,
                     projectJsonPath);
-            }
-            else
-            {
-                // Restore an unknown file type using the file name
-                // without the extension as the Id
-                var projectName = Path.GetFileNameWithoutExtension(inputPath);
-                projectJsonPath = BuildIntegratedProjectUtility.GetProjectConfigPath(inputPath, projectName);
 
-                Console.LogVerbose($"Reading project file {projectJsonPath}");
+                Console.LogVerbose($"Loaded project {packageSpec.Name} from {packageSpec.FilePath}");
 
-                packageSpec = JsonPackageSpecReader.GetPackageSpec(
-                    File.ReadAllText(projectJsonPath),
-                    projectName,
-                    projectJsonPath);
-            }
+                // Resolve the root directory
+                var rootDirectory = PackageSpecResolver.ResolveRootDirectory(inputPath);
+                Console.LogVerbose($"Found project root directory: {rootDirectory}");
 
-            Console.LogVerbose($"Loaded project {packageSpec.Name} from {packageSpec.FilePath}");
+                Console.LogVerbose($"Using packages directory: {packagesDir}");
 
-            // Resolve the root directory
-            var rootDirectory = PackageSpecResolver.ResolveRootDirectory(inputPath);
-            Console.LogVerbose($"Found project root directory: {rootDirectory}");
+                var packageSources = GetPackageSources(Settings);
+                var request = new RestoreRequest(
+                    packageSpec,
+                    packageSources);
 
-            Console.LogVerbose($"Using packages directory: {packagesDir}");
+                request.PackagesDirectory = packagesDir;
 
-            var packageSources = GetPackageSources(Settings);
-            var request = new RestoreRequest(
-                packageSpec,
-                packageSources);
-
-            request.PackagesDirectory = packagesDir;
-
-            if (DisableParallelProcessing)
-            {
-                request.MaxDegreeOfConcurrency = 1;
-            }
-            else
-            {
-                request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
-            }
-
-            request.CacheContext.NoCache = NoCache;
-
-            // Read the existing lock file, this is needed to support IsLocked=true
-            var lockFilePath = BuildIntegratedProjectUtility.GetLockFilePath(projectJsonPath);
-            request.LockFilePath = lockFilePath;
-            request.ExistingLockFile = BuildIntegratedRestoreUtility.GetLockFile(lockFilePath, Console);
-
-            // Resolve the packages directory
-            Console.LogVerbose($"Using packages directory: {request.PackagesDirectory}");
-
-            if (externalProjects != null)
-            {
-                foreach (var externalReference in externalProjects)
+                if (DisableParallelProcessing)
                 {
-                    var projectDir = Path.GetDirectoryName(externalReference);
-                    var projectName = Path.GetFileNameWithoutExtension(externalReference);
-                    var childProjectJson =
-                        BuildIntegratedProjectUtility.GetProjectConfigPath(projectDir, projectName);
-
-                    Debug.Assert(childProjectJson != null && File.Exists(childProjectJson), childProjectJson);
-
-                    request.ExternalProjects.Add(
-                        new ExternalProjectReference(
-                            externalReference,
-                            childProjectJson,
-                            projectReferences: Enumerable.Empty<string>()));
+                    request.MaxDegreeOfConcurrency = 1;
                 }
+                else
+                {
+                    request.MaxDegreeOfConcurrency = PackageManagementConstants.DefaultMaxDegreeOfParallelism;
+                }
+
+                request.CacheContext.NoCache = NoCache;
+
+                // Read the existing lock file, this is needed to support IsLocked=true
+                var lockFilePath = BuildIntegratedProjectUtility.GetLockFilePath(projectJsonPath);
+                request.LockFilePath = lockFilePath;
+                request.ExistingLockFile = BuildIntegratedRestoreUtility.GetLockFile(lockFilePath, Console);
+
+                // Resolve the packages directory
+                Console.LogVerbose($"Using packages directory: {request.PackagesDirectory}");
+
+                if (externalProjects != null)
+                {
+                    foreach (var externalReference in externalProjects)
+                    {
+                        var projectDir = Path.GetDirectoryName(externalReference);
+                        var childProjectName = Path.GetFileNameWithoutExtension(externalReference);
+                        var childProjectJson =
+                            BuildIntegratedProjectUtility.GetProjectConfigPath(projectDir, childProjectName);
+
+                        Debug.Assert(childProjectJson != null && File.Exists(childProjectJson), childProjectJson);
+
+                        request.ExternalProjects.Add(
+                            new ExternalProjectReference(
+                                externalReference,
+                                childProjectJson,
+                                projectReferences: Enumerable.Empty<string>()));
+                    }
+                }
+
+                CheckRequireConsent();
+
+                // Run the restore
+                var command = new Commands.RestoreCommand(Console, request);
+                var result = await command.ExecuteAsync();
+                result.Commit(Console);
+
+                success = result.Success;
             }
 
-            CheckRequireConsent();
-
-            // Run the restore
-            var command = new Commands.RestoreCommand(Console, request);
-            var result = await command.ExecuteAsync();
-            result.Commit(Console);
-
-            return result.Success;
+            return success;
         }
 
         private void ReadSettings(PackageRestoreInputs packageRestoreInputs)
@@ -324,7 +323,7 @@ namespace NuGet.CommandLine
                 {
                     var message = string.Format(
                         CultureInfo.CurrentCulture,
-                        "RestoreCommandFileNotFound",
+                        LocalizedResourceManager.GetString("RestoreCommandFileNotFound"),
                         packageReferenceFile);
 
                     throw new InvalidOperationException(message);
@@ -460,8 +459,20 @@ namespace NuGet.CommandLine
 
                 if (BuildIntegratedProjectUtility.IsProjectConfig(projectFileName))
                 {
-                    // project.json or projName.project.json
-                    packageRestoreInputs.V3RestoreFiles.Add(projectFilePath);
+                    if (File.Exists(projectFilePath))
+                    {
+                        // project.json or projName.project.json
+                        packageRestoreInputs.V3RestoreFiles.Add(projectFilePath);
+                    }
+                    else
+                    {
+                        var message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("RestoreCommandFileNotFound"),
+                            projectFilePath);
+
+                        throw new InvalidOperationException(message);
+                    }
                 }
                 else if (string.Equals(projectFileName, Constants.PackageReferenceFile)
                     || (projectFileName.StartsWith("packages.", StringComparison.OrdinalIgnoreCase)
@@ -474,6 +485,16 @@ namespace NuGet.CommandLine
                 }
                 else if (MsBuildUtility.IsMsBuildBasedProject(projectFileName))
                 {
+                    if (!File.Exists(projectFilePath))
+                    {
+                        var message = string.Format(
+                            CultureInfo.CurrentCulture,
+                            LocalizedResourceManager.GetString("RestoreCommandFileNotFound"),
+                            projectFilePath);
+
+                        throw new InvalidOperationException(message);
+                    }
+
                     // For msbuild files find the project.json or packages.config file,
                     // if neither exist skip it
 

--- a/src/NuGet.CommandLine/Common/ExitCodeException.cs
+++ b/src/NuGet.CommandLine/Common/ExitCodeException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NuGet.CommandLine
+{
+    [Serializable]
+    public class ExitCodeException : CommandLineException
+    {
+        public ExitCodeException(int exitCode)
+            : base()
+        {
+            ExitCode = exitCode;
+        }
+
+        public int ExitCode { get; }
+    }
+}

--- a/src/NuGet.CommandLine/Common/ProjectHelper.cs
+++ b/src/NuGet.CommandLine/Common/ProjectHelper.cs
@@ -25,6 +25,19 @@ namespace NuGet.Common
             }
         }
 
+        private static readonly HashSet<string> _unsupportedProjectExtensions 
+            = new HashSet<string>(StringComparer.OrdinalIgnoreCase) {
+                ".xproj"
+            };
+
+        public static HashSet<string> UnsupportedProjectExtensions
+        {
+            get
+            {
+                return _unsupportedProjectExtensions;
+            }
+        }
+
         public static bool TryGetProjectFile(string directory, out string projectFile)
         {
             projectFile = null;

--- a/src/NuGet.CommandLine/NuGet.CommandLine.csproj
+++ b/src/NuGet.CommandLine/NuGet.CommandLine.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Common\Console.cs" />
     <Compile Include="Common\ConsoleCredentialProvider.cs" />
     <Compile Include="Common\ConsoleProjectContext.cs" />
+    <Compile Include="Common\ExitCodeException.cs" />
     <Compile Include="Common\IConsole.cs" />
     <Compile Include="Common\IMSBuildProjectSystem.cs" />
     <Compile Include="Common\LocalizedResourceManager.cs" />
@@ -135,6 +136,7 @@
     <EmbeddedResource Include="NuGetResources.resx">
       <Generator>PublicResXFileCodeGenerator</Generator>
       <LastGenOutput>NuGetResources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/src/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.CommandLine/Program.cs
@@ -119,6 +119,12 @@ namespace NuGet.CommandLine
                 {
                     message = getErrorMessage(unwrappedEx.InnerException);
                 }
+                else if (unwrappedEx is ExitCodeException)
+                {
+                    // Return the exit code without writing out the exception type
+                    var exitCodeEx = unwrappedEx as ExitCodeException;
+                    return exitCodeEx.ExitCode;
+                }
                 else
                 {
                     message = getErrorMessage(unwrappedEx);


### PR DESCRIPTION
This change adds additional validation to restore command inputs.
- DNX projects will be skipped during restore
- Restore <missing project.json> would return the exception message from NuGet.Commands instead of the localized nuget.exe resource.
- Restore <missing .csproj> now gives an error message describing the problem
- Fixed an error message which printed out the resource name instead of the actual string for RestoreCommandFileNotFound 
- Added ExitCodeException to handle setting a non-zero exit code. This gets rid of the non-meaningful error message about a CommandLineException being thrown.

https://github.com/NuGet/Home/issues/1227
https://github.com/NuGet/Home/issues/1311

//cc @deepakaravindr @feiling @zhili1208 @MeniZalzman @yishaigalatzer 
