### PR TITLE
Allow duplicate ids from packages.config during restore (part 2)

### DIFF
--- a/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
+++ b/src/NuGet.CommandLine/Commands/DownloadCommandBase.cs
@@ -75,7 +75,9 @@ namespace NuGet.CommandLine
             }
         }
 
-        protected IEnumerable<Packaging.PackageReference> GetInstalledPackageReferences(string projectConfigFilePath)
+        protected IEnumerable<Packaging.PackageReference> GetInstalledPackageReferences
+            (string projectConfigFilePath,
+            bool allowDuplicatePackageIds)
         {
             if (File.Exists(projectConfigFilePath))
             {
@@ -83,7 +85,7 @@ namespace NuGet.CommandLine
                 {
                     var xDocument = XDocument.Load(projectConfigFilePath);
                     var reader = new PackagesConfigReader(XDocument.Load(projectConfigFilePath));
-                    return reader.GetPackages();
+                    return reader.GetPackages(allowDuplicatePackageIds);
                 }
                 catch (XmlException ex)
                 {

--- a/src/NuGet.CommandLine/Commands/InstallCommand.cs
+++ b/src/NuGet.CommandLine/Commands/InstallCommand.cs
@@ -145,7 +145,11 @@ namespace NuGet.CommandLine
         {
             var sourceRepositoryProvider = GetSourceRepositoryProvider();
             var nuGetPackageManager = new NuGetPackageManager(sourceRepositoryProvider, Settings, installPath);
-            var installedPackageReferences = GetInstalledPackageReferences(packagesConfigFilePath);
+
+            var installedPackageReferences = GetInstalledPackageReferences(
+                packagesConfigFilePath,
+                allowDuplicatePackageIds: true);
+
             var packageRestoreData = installedPackageReferences.Select(reference =>
                 new PackageRestoreData(
                     reference,

--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -308,7 +308,7 @@ namespace NuGet.CommandLine
             {
                 installedPackageReferences.AddRange(packageRestoreInputs
                     .PackageReferenceFiles
-                    .SelectMany(GetInstalledPackageReferences));
+                    .SelectMany(file => GetInstalledPackageReferences(file, allowDuplicatePackageIds: true)));
             }
             else if (packageRestoreInputs.PackageReferenceFiles.Count > 0)
             {
@@ -330,7 +330,8 @@ namespace NuGet.CommandLine
                     throw new InvalidOperationException(message);
                 }
 
-                installedPackageReferences.AddRange(GetInstalledPackageReferences(packageReferenceFile));
+                installedPackageReferences.AddRange(
+                    GetInstalledPackageReferences(packageReferenceFile, allowDuplicatePackageIds: true));
             }
 
             var missingPackageReferences = installedPackageReferences.Where(reference =>


### PR DESCRIPTION
This change makes use of the packages config reader flag to allow duplicate package id entries. nuget.exe needs to restore solution level packages.config files which may have duplicate ids.

//cc @deepakaravindr @feiling @danliu @yishaigalatzer 
