### PR TITLE
Restore result is incorrect with DisableParallelProcessing

### DIFF
--- a/src/NuGet.CommandLine/Commands/RestoreCommand.cs
+++ b/src/NuGet.CommandLine/Commands/RestoreCommand.cs
@@ -86,7 +86,7 @@ namespace NuGet.CommandLine
                 {
                     if (DisableParallelProcessing)
                     {
-                        await PerformNuGetV3RestoreAsync(packagesDir, file);
+                        restoreResult &= await PerformNuGetV3RestoreAsync(packagesDir, file);
                     }
                     else
                     {


### PR DESCRIPTION
When DisableParallelProcessing is set and a project.json restore fails the exit code is incorrectly set to zero.

//cc @zhili1208 @deepakaravindr @yishaigalatzer 
