### PR TITLE
Fixes nuget.exe update issue with not deleting old content files

### DIFF
--- a/src/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
+++ b/src/NuGet.CommandLine/Common/MSBuildProjectSystem.cs
@@ -219,7 +219,8 @@ namespace NuGet.Common
 
         public void RemoveFile(string path)
         {
-            FileSystemUtility.DeleteFile(path, NuGetProjectContext);
+            var fullPath = Path.Combine(ProjectFullPath, path);
+            FileSystemUtility.DeleteFile(fullPath, NuGetProjectContext);
         }
 
         public void RemoveImport(string targetFullPath)

--- a/test/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
+++ b/test/NuGet.CommandLine.Test/MSBuildProjectSystemTests.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using NuGet.Common;
+using Test.Utility;
+using Xunit;
+
+namespace NuGet.CommandLine.Test
+{
+    public class MSBuildProjectSystemTests
+    {
+        private class TestInfo : IDisposable
+        {
+            public MSBuildProjectSystem MSBuildProjSystem { get; }
+            private string ProjectDirectory { get; }
+            private string MSBuildDirectory { get; }
+            private TestNuGetProjectContext NuGetProjectContext { get; }
+
+            public TestInfo(string projectFileContent, string projectName = "proj1")
+            {
+                ProjectDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+                MSBuildDirectory = MsBuildUtility.GetMsbuildDirectory("14.0", null);
+                NuGetProjectContext = new TestNuGetProjectContext();
+
+                var projectFilePath = Path.Combine(ProjectDirectory, projectName + ".csproj");
+                File.WriteAllText(projectFilePath, projectFileContent);
+
+                MSBuildProjSystem 
+                    = new MSBuildProjectSystem(MSBuildDirectory, projectFilePath, NuGetProjectContext);
+            }
+
+            public void Dispose()
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(ProjectDirectory);
+            }
+        }
+
+        [Fact]
+        public void MSBuildProjectSystem_AddFile()
+        {
+            // Arrange
+            var projectFileContent = Util.CreateProjFileContent();
+            using (var testInfo = new TestInfo(projectFileContent))
+            {
+                var expectedContent = "one two three";
+                using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(expectedContent)))
+                {
+                    // Act
+                    testInfo.MSBuildProjSystem.AddFile("a.js", stream);
+
+                    // Assert
+                    var path = Path.Combine(testInfo.MSBuildProjSystem.ProjectFullPath, "a.js");
+                    Assert.True(File.Exists(path), path + "should exist, but it does not.");
+
+                    var actualContent = File.ReadAllText(path);
+                    Assert.Equal(expectedContent, actualContent);
+                }
+            }
+        }
+
+        [Fact]
+        public void MSBuildProjectSystem_RemoveFile()
+        {
+            // Arrange
+            var projectFileContent = Util.CreateProjFileContent(
+                "proj1",
+                "v4.5",
+                references: null,
+                contentFiles: new[] { "a.js" });
+
+            using (var testInfo = new TestInfo(projectFileContent))
+            {
+                var path = Path.Combine(testInfo.MSBuildProjSystem.ProjectFullPath, "a.js");
+                var expectedContent = "one two three";
+                File.WriteAllText(path, expectedContent);
+
+                Assert.True(File.Exists(path), path + "should exist, but it does not.");
+
+                // Act
+                testInfo.MSBuildProjSystem.RemoveFile("a.js");
+
+                // Assert
+                Assert.False(File.Exists(path), path + "should not exist, but it does.");
+            }
+        }
+
+        [Fact]
+        public void MSBuildProjectSystem_FileExistInProject()
+        {
+            // Arrange
+            var projectFileContent = Util.CreateProjFileContent(
+                "proj1",
+                "v4.5",
+                references: null,
+                contentFiles: new[] { "a.js" });
+
+            using (var testInfo = new TestInfo(projectFileContent))
+            {
+                var path = Path.Combine(testInfo.MSBuildProjSystem.ProjectFullPath, "a.js");
+                var expectedContent = "one two three";
+                File.WriteAllText(path, expectedContent);
+
+                Assert.True(File.Exists(path), path + "should exist, but it does not.");
+
+                // Act
+                var fileExistsInProject = testInfo.MSBuildProjSystem.FileExistsInProject("a.js");
+
+                // Assert
+                Assert.True(fileExistsInProject, "a.js does not exist in project");
+            }
+        }
+    }
+}

--- a/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
+++ b/test/NuGet.CommandLine.Test/NuGet.CommandLine.Test.csproj
@@ -62,6 +62,7 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>MockServerResource.resx</DependentUpon>
     </Compile>
+    <Compile Include="MSBuildProjectSystemTests.cs" />
     <Compile Include="MSBuildUtilityTest.cs" />
     <Compile Include="NetworkCallCountTest.cs" />
     <Compile Include="NuGetConfigCommandTest.cs" />

--- a/test/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -53,28 +53,10 @@ namespace NuGet.CommandLine.Test
                 Util.CreateFile(
                     projectDirectory,
                     "proj1.csproj",
-    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='proj1_file1.cs' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='proj1_file2.txt' />
-  </ItemGroup>
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
-</Project>");
+                    Util.CreateProjFileContent());
 
                 Util.CreateFile(solutionDirectory, "a.sln",
-                    @"
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
-EndProject");
+                    Util.CreateSolutionFileContent());
 
                 var projectFile = Path.Combine(projectDirectory, "proj1.csproj");
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
@@ -86,7 +68,11 @@ EndProject");
                 using (var stream = File.OpenRead(a1Package))
                 {
                     var downloadResult = new DownloadResourceResult(stream);
-                    await msBuildProject.InstallPackageAsync(a1, downloadResult, testNuGetProjectContext, CancellationToken.None);
+                    await msBuildProject.InstallPackageAsync(
+                        a1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
                 }
 
                 var args = new[]
@@ -151,28 +137,10 @@ EndProject");
                 Util.CreateFile(
                     projectDirectory,
                     "proj1.csproj",
-    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='proj1_file1.cs' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='proj1_file2.txt' />
-  </ItemGroup>
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
-</Project>");
+                    Util.CreateProjFileContent());
 
                 Util.CreateFile(solutionDirectory, "a.sln",
-                    @"
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
-EndProject");
+                    Util.CreateSolutionFileContent());
 
                 var projectFile = Path.Combine(projectDirectory, "proj1.csproj");
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
@@ -184,7 +152,11 @@ EndProject");
                 using (var stream = File.OpenRead(a1Package))
                 {
                     var downloadResult = new DownloadResourceResult(stream);
-                    await msBuildProject.InstallPackageAsync(a1, downloadResult, testNuGetProjectContext, CancellationToken.None);
+                    await msBuildProject.InstallPackageAsync(
+                        a1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
                 }
 
                 var args = new[]
@@ -248,28 +220,10 @@ EndProject");
                 Util.CreateFile(
                     projectDirectory,
                     "proj1.csproj",
-    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='proj1_file1.cs' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='proj1_file2.txt' />
-  </ItemGroup>
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
-</Project>");
+                    Util.CreateProjFileContent());
 
                 Util.CreateFile(solutionDirectory, "a.sln",
-                    @"
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
-EndProject");
+                    Util.CreateSolutionFileContent());
 
                 var projectFile = Path.Combine(projectDirectory, "proj1.csproj");
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
@@ -281,7 +235,11 @@ EndProject");
                 using (var stream = File.OpenRead(a1Package))
                 {
                     var downloadResult = new DownloadResourceResult(stream);
-                    await msBuildProject.InstallPackageAsync(a1, downloadResult, testNuGetProjectContext, CancellationToken.None);
+                    await msBuildProject.InstallPackageAsync(
+                        a1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
                 }
 
                 var args = new[]
@@ -347,28 +305,10 @@ EndProject");
                 Util.CreateFile(
                     projectDirectory,
                     "proj1.csproj",
-    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='proj1_file1.cs' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='proj1_file2.txt' />
-  </ItemGroup>
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
-</Project>");
+                    Util.CreateProjFileContent());
 
                 Util.CreateFile(solutionDirectory, "a.sln",
-                    @"
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
-EndProject");
+                    Util.CreateSolutionFileContent());
 
                 var projectFile = Path.Combine(projectDirectory, "proj1.csproj");
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
@@ -380,7 +320,11 @@ EndProject");
                 using (var stream = File.OpenRead(a1Package))
                 {
                     var downloadResult = new DownloadResourceResult(stream);
-                    await msBuildProject.InstallPackageAsync(a1, downloadResult, testNuGetProjectContext, CancellationToken.None);
+                    await msBuildProject.InstallPackageAsync(
+                        a1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
                 }
 
                 var args = new[]
@@ -445,28 +389,10 @@ EndProject");
                 Util.CreateFile(
                     projectDirectory,
                     "proj1.csproj",
-    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='proj1_file1.cs' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='proj1_file2.txt' />
-  </ItemGroup>
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
-</Project>");
+                    Util.CreateProjFileContent());
 
                 Util.CreateFile(solutionDirectory, "a.sln",
-                    @"
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"", ""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
-EndProject");
+                    Util.CreateSolutionFileContent());
 
                 var projectFile = Path.Combine(projectDirectory, "proj1.csproj");
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
@@ -479,7 +405,11 @@ EndProject");
                 using (var stream = File.OpenRead(a1Package))
                 {
                     var downloadResult = new DownloadResourceResult(stream);
-                    await msBuildProject.InstallPackageAsync(a1, downloadResult, testNuGetProjectContext, CancellationToken.None);
+                    await msBuildProject.InstallPackageAsync(
+                        a1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
                 }
 
                 var args = new[]
@@ -544,29 +474,10 @@ EndProject");
                 Util.CreateFile(
                     projectDirectory,
                     "proj1.csproj",
-    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='proj1_file1.cs' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='proj1_file2.txt' />
-  </ItemGroup>
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
-</Project>");
+                    Util.CreateProjFileContent());
 
                 Util.CreateFile(solutionDirectory, "a.sln",
-                    @"
-Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2012
-Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"",
-""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
-EndProject");
+                    Util.CreateSolutionFileContent());
 
                 var projectFile = Path.Combine(projectDirectory, "proj1.csproj");
                 var solutionFile = Path.Combine(solutionDirectory, "a.sln");
@@ -591,24 +502,11 @@ EndProject");
                 // Replace proj1.csproj with content files on it, like Install-Package from VS would have.
                 File.Delete(projectFile);
                 File.WriteAllText(projectFile,
-    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
-    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
-  <PropertyGroup>
-    <OutputType>Library</OutputType>
-    <OutputPath>out</OutputPath>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include='proj1_file1.cs' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='proj1_file2.txt' />
-  </ItemGroup>
-  <ItemGroup>
-    <Content Include='test1.txt' />
-  </ItemGroup>
-  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
-</Project>");
+                    Util.CreateProjFileContent(
+                        "proj1",
+                        "v4.5",
+                        references: null,
+                        contentFiles: new[] { "test1.txt" }));
 
                 var args = new[]
                 {

--- a/test/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
+++ b/test/NuGet.CommandLine.Test/NuGetUpdateCommandTests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Common;
@@ -500,6 +501,156 @@ EndProject");
                 var content = File.ReadAllText(projectFile);
                 Assert.False(content.Contains(@"<HintPath>..\packages\A.1.0.0\lib\net45\file.dll</HintPath>"));
                 Assert.True(content.Contains(@"<HintPath>..\packages\A.2.0.0\lib\net45\file.dll</HintPath>"));
+            }
+            finally
+            {
+                TestFilesystemUtility.DeleteRandomTestFolders(solutionDirectory, workingPath, packagesSourceDirectory);
+            }
+        }
+
+        [Fact]
+        public async Task UpdateCommand_Success_ContentFiles()
+        {
+            // Arrange
+            var packagesSourceDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+            var solutionDirectory = TestFilesystemUtility.CreateRandomTestFolder();
+            var projectDirectory = Path.Combine(solutionDirectory, "proj1");
+            var packagesDirectory = Path.Combine(solutionDirectory, "packages");
+            var workingPath = TestFilesystemUtility.CreateRandomTestFolder();
+
+            try
+            {
+                var a1 = new PackageIdentity("A", new NuGetVersion("1.0.0"));
+                var a2 = new PackageIdentity("A", new NuGetVersion("2.0.0"));
+
+                var a1Package = Util.CreateTestPackage(
+                    a1.Id,
+                    a1.Version.ToString(),
+                    packagesSourceDirectory,
+                    licenseUrl: null,
+                    contentFiles: "test1.txt");
+
+                var a2Package = Util.CreateTestPackage(
+                    a2.Id,
+                    a2.Version.ToString(),
+                    packagesSourceDirectory,
+                    licenseUrl: null,
+                    contentFiles: "test2.txt");
+
+                var packagesFolder = PathUtility.GetRelativePath(projectDirectory, packagesDirectory);
+
+                Directory.CreateDirectory(projectDirectory);
+                // create project 1
+                Util.CreateFile(
+                    projectDirectory,
+                    "proj1.csproj",
+    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include='proj1_file1.cs' />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include='proj1_file2.txt' />
+  </ItemGroup>
+  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+</Project>");
+
+                Util.CreateFile(solutionDirectory, "a.sln",
+                    @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"",
+""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
+EndProject");
+
+                var projectFile = Path.Combine(projectDirectory, "proj1.csproj");
+                var solutionFile = Path.Combine(solutionDirectory, "a.sln");
+
+                var testNuGetProjectContext = new TestNuGetProjectContext();
+                var msbuildDirectory = MsBuildUtility.GetMsbuildDirectory("14.0", null);
+                var projectSystem = new MSBuildProjectSystem(msbuildDirectory, projectFile, testNuGetProjectContext);
+                var msBuildProject = new MSBuildNuGetProject(projectSystem, packagesDirectory, projectDirectory);
+                using (var stream = File.OpenRead(a1Package))
+                {
+                    var downloadResult = new DownloadResourceResult(stream);
+                    await msBuildProject.InstallPackageAsync(
+                        a1,
+                        downloadResult,
+                        testNuGetProjectContext,
+                        CancellationToken.None);
+                }
+
+                // Since, content files do not get added by MSBuildProjectSystem used by nuget.exe only,
+                // the csproj file will not have the entries for content files.
+                // Note that MSBuildProjectSystem used by nuget.exe only, can add or remove references from csproj.
+                // Replace proj1.csproj with content files on it, like Install-Package from VS would have.
+                File.Delete(projectFile);
+                File.WriteAllText(projectFile,
+    @"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include='proj1_file1.cs' />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include='proj1_file2.txt' />
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include='test1.txt' />
+  </ItemGroup>
+  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+</Project>");
+
+                var args = new[]
+                {
+                    "update",
+                    solutionFile,
+                    "-Source",
+                    packagesSourceDirectory
+                };
+
+                var test1textPath = Path.Combine(projectDirectory, "test1.txt");
+                var test2textPath = Path.Combine(projectDirectory, "test2.txt");
+                var packagesConfigPath = Path.Combine(projectDirectory, "packages.config");
+
+                Assert.True(File.Exists(test1textPath), "Content file test1.txt should exist but does not.");
+                Assert.False(File.Exists(test2textPath), "Content file test2.txt should not exist but does.");
+                using (var packagesConfigStream = File.OpenRead(packagesConfigPath))
+                {
+                    var packagesConfigReader = new PackagesConfigReader(packagesConfigStream);
+                    var packages = packagesConfigReader.GetPackages().ToList();
+                    Assert.Equal(1, packages.Count);
+                    Assert.Equal(a1, packages[0].PackageIdentity);
+                }
+
+                // Act
+                var r = CommandRunner.Run(
+                    Util.GetNuGetExePath(),
+                    workingPath,
+                    string.Join(" ", args),
+                    waitForExit: true);
+
+                // Assert
+                Assert.True(r.Item1 == 0, "Output is " + r.Item2 + ". Error is " + r.Item3);
+                Assert.False(File.Exists(test1textPath), "Content file test1.txt should not exist but does.");
+                Assert.True(File.Exists(test2textPath), "Content file test2.txt should exist but does not.");
+
+                using (var packagesConfigStream = File.OpenRead(packagesConfigPath))
+                {
+                    var packagesConfigReader = new PackagesConfigReader(packagesConfigStream);
+                    var packages = packagesConfigReader.GetPackages().ToList();
+                    Assert.Equal(1, packages.Count);
+                    Assert.Equal(a2, packages[0].PackageIdentity);
+                }
             }
             finally
             {

--- a/test/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.CommandLine.Test/Util.cs
@@ -26,7 +26,7 @@ namespace NuGet.CommandLine.Test
             string dependencyPackageId,
             string dependencyPackageVersion)
         {
-            var group = new PackageDependencyGroup(NuGetFramework.AnyFramework, 
+            var group = new PackageDependencyGroup(NuGetFramework.AnyFramework,
                 new List<Packaging.Core.PackageDependency>()
             {
                 new Packaging.Core.PackageDependency(dependencyPackageId, VersionRange.Parse(dependencyPackageVersion))
@@ -58,8 +58,8 @@ namespace NuGet.CommandLine.Test
             foreach (var framework in frameworks)
             {
                 var libPath = string.Format(
-                    CultureInfo.InvariantCulture, 
-                    "lib/{0}/file.dll", 
+                    CultureInfo.InvariantCulture,
+                    "lib/{0}/file.dll",
                     framework.GetShortFolderName());
 
                 packageBuilder.Files.Add(CreatePackageFile(libPath));
@@ -70,9 +70,9 @@ namespace NuGet.CommandLine.Test
             foreach (var group in dependencies)
             {
                 var set = new PackageDependencySet(
-                    null, 
-                    group.Packages.Select(package => 
-                        new PackageDependency(package.Id, 
+                    null,
+                    group.Packages.Select(package =>
+                        new PackageDependency(package.Id,
                             VersionUtility.ParseVersionSpec(package.VersionRange.ToNormalizedString()))));
 
                 packageBuilder.DependencySets.Add(set);
@@ -124,7 +124,7 @@ namespace NuGet.CommandLine.Test
             }
             else
             {
-                foreach(var contentFile in contentFiles)
+                foreach (var contentFile in contentFiles)
                 {
                     var packageFilePath = Path.Combine("content", contentFile);
                     var packageFile = CreatePackageFile(packageFilePath);
@@ -503,6 +503,72 @@ namespace NuGet.CommandLine.Test
             catalogEntry.Add(new JProperty("tags", new JArray()));
 
             return regBlob;
+        }
+
+        public static string CreateProjFileContent(
+            string projectName = "proj1",
+            string targetFrameworkVersion = "v4.5",
+            string[] references = null,
+            string[] contentFiles = null)
+        {
+            var referencesFormat = "<Reference Include='{0}' />";
+
+            var contentFileFormat = @"<Content Include = '{0}' />";
+
+            var projFileFormat = @"<Project ToolsVersion='4.0' DefaultTargets='Build'
+    xmlns='http://schemas.microsoft.com/developer/msbuild/2003'>
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <OutputPath>out</OutputPath>
+    <TargetFrameworkVersion>{0}</TargetFrameworkVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include='proj1_file1.cs' />
+  </ItemGroup>
+  {1}
+  {2}
+  <Import Project='$(MSBuildToolsPath)\Microsoft.CSharp.targets' />
+</Project>";
+
+            var referencesSection = new StringBuilder();
+            if (references != null)
+            {
+                referencesSection.Append("<ItemGroup>");
+                foreach(var reference in references)
+                {
+                    var referenceEntry = string.Format(referencesFormat, reference);
+                    referencesSection.Append(referenceEntry);
+                }
+                referencesSection.Append("</ItemGroup>");
+            }
+
+            var contentFilesSection = new StringBuilder();
+            if (contentFiles != null)
+            {
+                contentFilesSection.Append("<ItemGroup>");
+                foreach (var contentFile in contentFiles)
+                {
+                    var contentFileEntry = string.Format(contentFileFormat, contentFile);
+                    contentFilesSection.Append(contentFileEntry);
+                }
+                contentFilesSection.Append("</ItemGroup>");
+            }
+
+            return string.Format(
+                projFileFormat,
+                targetFrameworkVersion,
+                referencesSection.ToString(),
+                contentFilesSection.ToString());
+        }
+
+        public static string CreateSolutionFileContent()
+        {
+            return @"
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 2012
+Project(""{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}"") = ""proj1"",
+""proj1.csproj"", ""{A04C59CC-7622-4223-B16B-CDF2ECAD438D}""
+EndProject";
         }
     }
 }

--- a/test/NuGet.CommandLine.Test/Util.cs
+++ b/test/NuGet.CommandLine.Test/Util.cs
@@ -96,7 +96,12 @@ namespace NuGet.CommandLine.Test
         /// <param name="version">The version of the created package.</param>
         /// <param name="path">The directory where the package is created.</param>
         /// <returns>The full path of the created package file.</returns>
-        public static string CreateTestPackage(string packageId, string version, string path, Uri licenseUrl = null)
+        public static string CreateTestPackage(
+            string packageId,
+            string version,
+            string path,
+            Uri licenseUrl = null,
+            params string[] contentFiles)
         {
             var packageBuilder = new PackageBuilder
             {
@@ -113,7 +118,20 @@ namespace NuGet.CommandLine.Test
                 packageBuilder.LicenseUrl = licenseUrl;
             }
 
-            packageBuilder.Files.Add(CreatePackageFile(@"content\test1.txt"));
+            if (contentFiles == null || contentFiles.Length == 0)
+            {
+                packageBuilder.Files.Add(CreatePackageFile(@"content\test1.txt"));
+            }
+            else
+            {
+                foreach(var contentFile in contentFiles)
+                {
+                    var packageFilePath = Path.Combine("content", contentFile);
+                    var packageFile = CreatePackageFile(packageFilePath);
+                    packageBuilder.Files.Add(packageFile);
+                }
+            }
+
             packageBuilder.Authors.Add("test author");
 
             var packageFileName = string.Format("{0}.{1}.nupkg", packageId, version);


### PR DESCRIPTION
Fixes NuGet/Home#1498

On remove file, we are passing the path relative to the project directory
to DeleteFile method. It should be the full path.

Added a test to determine that the files are deleted as needed

@yishaigalatzer @danliu @MeniZalzman @feiling 
