### PR TITLE
Fixes functional test failure: InstallPackageConsidersPrereleasePackagesWhenResolvingDependencyWhenPrereleaseFlagIsNotSpecified

### DIFF
--- a/src/PackageManagement/Context/ResolutionContext.cs
+++ b/src/PackageManagement/Context/ResolutionContext.cs
@@ -63,6 +63,6 @@ namespace NuGet.PackageManagement
         /// Ex: Update-Package updates all packages across all projects, GatherCache stores
         /// the gathered packages and re-uses them across all sub operations.
         /// </summary>
-        internal GatherCache GatherCache { get; }
+        public GatherCache GatherCache { get; }
     }
 }

--- a/src/PackageManagement/NuGetPackageManager.cs
+++ b/src/PackageManagement/NuGetPackageManager.cs
@@ -1950,6 +1950,11 @@ namespace NuGet.PackageManagement
             // resolution context for the gather to use during the next step.
             // Using the metadata resource will result in multiple calls to the same url during an install.
             var packages = await dependencyInfoResource.ResolvePackages(packageId, framework, token);
+            packages = packages.Select(package =>
+            {
+                package.SetIncludePrereleaseForDependencies();
+                return package;
+            });
 
             Debug.Assert(resolutionContext.GatherCache != null);
 

--- a/src/PackageManagement/Resolution/GatherCache.cs
+++ b/src/PackageManagement/Resolution/GatherCache.cs
@@ -15,7 +15,7 @@ namespace NuGet.PackageManagement
     /// <summary>
     /// GatherCache contains cached results from DependencyInfoResource providers
     /// </summary>
-    internal class GatherCache
+    public class GatherCache
     {
         // These are typically the primary targets or installed packages which perform the lookup on only a single version.
         private readonly ConcurrentDictionary<GatherSingleCacheKey, SourcePackageDependencyInfo> _singleVersion

--- a/src/PackageManagement/Resolution/GatherCacheResult.cs
+++ b/src/PackageManagement/Resolution/GatherCacheResult.cs
@@ -13,7 +13,7 @@ namespace NuGet.PackageManagement
     /// If a result has zero packages HasEntry will be true, but Packages will be empty.
     /// If the query has not been done HasEntry will be false.
     /// </summary>
-    internal class GatherCacheResult
+    public class GatherCacheResult
     {
         public GatherCacheResult(bool hasEntry, IReadOnlyList<SourcePackageDependencyInfo> packages)
         {

--- a/test/PackageManagement.Test/NuGetPackageManagerTests.cs
+++ b/test/PackageManagement.Test/NuGetPackageManagerTests.cs
@@ -3975,6 +3975,53 @@ namespace NuGet.Test
                 randomPackagesConfigFolderPath);
         }
 
+        [Fact]
+        public async Task TestPacManGetLatestVersion_GatherCache()
+        {
+            // Arrange
+            var packageIdentity = new PackageIdentity("a", new NuGetVersion(1, 0, 0));
+            var bVersionRange = VersionRange.Parse("[0.5.0, 2.0.0)");
+            var packages = new List<SourcePackageDependencyInfo>
+            {
+                new SourcePackageDependencyInfo(
+                    packageIdentity.Id,
+                    packageIdentity.Version,
+                    new[]
+                    {
+                        new Packaging.Core.PackageDependency("b", bVersionRange)
+                    },
+                    listed: true,
+                    source: null),
+            };
+
+            var resourceProviders = new List<Lazy<INuGetResourceProvider>>();
+            resourceProviders.Add(new Lazy<INuGetResourceProvider>(() => new TestDependencyInfoProvider(packages)));
+            resourceProviders.Add(new Lazy<INuGetResourceProvider>(() => new TestMetadataProvider(packages)));
+
+            var packageSource = new Configuration.PackageSource("http://a");
+            var packageSourceProvider = new TestPackageSourceProvider(new[] { packageSource });
+
+            var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, resourceProviders);
+            var resolutionContext = new ResolutionContext();
+
+            // Act
+            var latestVersion = await NuGetPackageManager.GetLatestVersionAsync(
+                "a",
+                NuGetFramework.AnyFramework,
+                resolutionContext,
+                sourceRepositoryProvider.GetRepositories().First(),
+                CancellationToken.None);
+
+            // Assert
+            var gatherCache = resolutionContext.GatherCache;
+            var gatherCacheResult = gatherCache.GetPackage(packageSource, packageIdentity, NuGetFramework.AnyFramework);
+            var packageInfo = gatherCacheResult.Packages.First();
+            var packageDependency = packageInfo.Dependencies.Single();
+            Assert.Equal("b", packageDependency.Id);
+            Assert.Equal(bVersionRange.ToString(), packageDependency.VersionRange.ToString());
+            Assert.True(packageDependency.VersionRange.IncludePrerelease);
+        }
+
         private class TestDownloadResourceProvider : ResourceProvider
         {
             public TestDownloadResourceProvider()


### PR DESCRIPTION
Fixes the failure where the PackageDependency do not have IncludePrerelease
set to true on NuGetPackageManager.GetLatestVersionCoreAsync()

@yishaigalatzer @emgarten @johnataylor 
