### PR TITLE
Remove German article prefix

### DIFF
--- a/src/NuGet.CommandLine/NuGetResources.resx
+++ b/src/NuGet.CommandLine/NuGetResources.resx
@@ -2133,7 +2133,7 @@ To prevent NuGet from downloading packages during build, open the Visual Studio 
     <value>server symbolů</value>
   </data>
   <data name="DefaultSymbolServer_deu" xml:space="preserve">
-    <value>der Symbolserver</value>
+    <value>Symbolserver</value>
   </data>
   <data name="DefaultSymbolServer_esp" xml:space="preserve">
     <value>servidor de símbolos</value>
@@ -2172,7 +2172,7 @@ To prevent NuGet from downloading packages during build, open the Visual Studio 
     <value>galerie NuGet</value>
   </data>
   <data name="LiveFeed_deu" xml:space="preserve">
-    <value>der NuGet-Katalog</value>
+    <value>NuGet-Katalog</value>
   </data>
   <data name="LiveFeed_esp" xml:space="preserve">
     <value>la galería NuGet</value>


### PR DESCRIPTION
Because of [article declension](https://en.wikipedia.org/wiki/German_declension#Articles) in German you can't just put a noun with an article ("der NuGet-Katalog") into any sentence. Removing the article isn't the perfect solution but yields acceptable results, e.g. "wird an Symbolserver übertragen" instead of "wird an der Symbolserver übertragen" (wrong).
