### PR TITLE
Add back loading extensions (by naming convention) from the program folder

### DIFF
--- a/src/NuGet.CommandLine/Program.cs
+++ b/src/NuGet.CommandLine/Program.cs
@@ -231,6 +231,13 @@ namespace NuGet.CommandLine
                     RegisterExtensions(catalog, files, console);
                 }
             }
+
+            // Ideally we want to look for all files. However, using MEF to identify imports results in assemblies being loaded and locked by our App Domain
+            // which could be slow, might affect people's build systems and among other things breaks our build.
+            // Consequently, we'll use a convention - only binaries ending in the name Extensions would be loaded.
+            var nugetDirectory = Path.GetDirectoryName(typeof(Program).Assembly.Location);
+            files = Directory.EnumerateFiles(nugetDirectory, "*Extensions.dll");
+            RegisterExtensions(catalog, files, console);
         }
 
         private static void RegisterExtensions(AggregateCatalog catalog, IEnumerable<string> enumerateFiles, IConsole console)


### PR DESCRIPTION
It looks like this exact code got dropped when NuGet.CommandLine moved repos.  This allows extensions to be loaded from the same directory as nuget.exe without having to specify NUGET_EXTENSIONS_PATH or use %LOCALAPPDATA%\NuGet\Commands.

This feature is useful in that NUGET_EXTENSIONS_PATH is used by multiple versions of nuget.exe 2.X and 3.X, while extensions are very likely only compatible with specific versions of nuget.exe.
